### PR TITLE
Fix initialization issues and improve UI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = { testEnvironment: 'jsdom' };

--- a/js/core.js
+++ b/js/core.js
@@ -65,6 +65,8 @@ window.addEventListener('DOMContentLoaded',()=>{
       spawnMode = false, spawnType = null, spawnZones = [],
       continueAfter = null;
 
+  Object.assign(window, { spawnZones });
+
   const state = {
     currentPlayer:1,
     turn:0,
@@ -76,6 +78,9 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   const map = Array.from({length:ROWS},()=>Array(COLS).fill(TERRAIN.PLAIN));
   const buildings = [], units = [];
+
+  // expose for tests
+  Object.assign(window, { map, buildings, units, TERRAIN, UNIT_TYPES, BUILD_TYPES });
 
   let cellW, cellH;
 
@@ -121,6 +126,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     sel = null;
     zoneMap = null; zoneList = [];
     spawnMode = false; spawnType = null; spawnZones = [];
+    window.spawnZones = spawnZones;
     continueAfter = null;
     state.currentPlayer = 1;
     state.turn = 0;
@@ -385,7 +391,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     units.push({r,c,owner:p,type,hp:UNIT_TYPES[type].hpMax,mp:0});
     state.gold[p]-=cost;
     recordEvent(`${UNIT_LABELS[type]} создан`);
-    spawnMode=false; spawnZones=[];
+    spawnMode=false; spawnZones=[]; window.spawnZones = spawnZones;
     updateAll();
   }
 
@@ -450,7 +456,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     if(spawnMode){
       let z=spawnZones.find(z=>z.r===y&&z.c===x);
       if(z) spawn(spawnType,y,x);
-      else { spawnMode=false; spawnZones=[]; updateAll(); }
+      else { spawnMode=false; spawnZones=[]; window.spawnZones = spawnZones; updateAll(); }
       return;
     }
     if(spawnPanel.style.display==='block'){ spawnPanel.style.display='none'; return; }
@@ -484,6 +490,7 @@ window.addEventListener('DOMContentLoaded',()=>{
                 map[z.r][z.c]!==TERRAIN.MOUNTAIN&&
                 !units.find(u=>u.r===z.r&&u.c===z.c)
               );
+              window.spawnZones = spawnZones;
               spawnMode=true; spawnPanel.style.display='none'; updateAll();
             };
             spawnPanel.appendChild(btn);
@@ -545,6 +552,7 @@ window.addEventListener('DOMContentLoaded',()=>{
               map[z.r][z.c]!==TERRAIN.MOUNTAIN&&
               !units.find(u=>u.r===z.r&&u.c===z.c)
             );
+            window.spawnZones = spawnZones;
             spawnMode=true; spawnPanel.style.display='none'; updateAll();
           };
           spawnPanel.appendChild(btn);
@@ -553,10 +561,21 @@ window.addEventListener('DOMContentLoaded',()=>{
     }
   });
 
+  // === right-click cancels selection ===
+  canvas.addEventListener('contextmenu',e=>{
+    e.preventDefault();
+    if(spawnMode){
+      spawnMode=false; spawnZones=[]; window.spawnZones = spawnZones; spawnPanel.style.display='none';
+    } else if(sel){
+      sel=null; zoneMap=null; zoneList=[];
+    }
+    updateAll();
+  });
+
   // === Передача хода ===
   endTurnBtn.addEventListener('click',()=>{
     if(gameOver) return;
-    spawnMode=false; spawnZones=[]; spawnPanel.style.display='none';
+    spawnMode=false; spawnZones=[]; window.spawnZones = spawnZones; spawnPanel.style.display='none';
     overlayMsg.textContent = `Передать ход игроку ${state.currentPlayer===1?2:1}?`;
     overlay.style.display = 'flex';
     continueAfter = ()=>{

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -6,23 +6,34 @@
  */
 
 const fs = require('fs');
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 const { JSDOM } = require('jsdom');
+HTMLCanvasElement.prototype.getContext = () => {
+  return {
+    fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
+    stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
+    moveTo:()=>{}, lineTo:()=>{}
+  };
+};
 
 describe('Fog of Conquest core', () => {
   let document, window, coreScript;
 
   beforeAll(async () => {
     const html = fs.readFileSync('index.html', 'utf8');
-    const dom = new JSDOM(html, { runScripts: "dangerously", resources: "usable" });
+    const dom = new JSDOM(html, { runScripts: "dangerously", resources: "usable", url: `file://${process.cwd()}/index.html` });
     document = dom.window.document;
     window = dom.window;
 
-    // Ждём загрузки core.js
     await new Promise(res => {
       document.addEventListener('DOMContentLoaded', () => {
         res();
       });
     });
+    // запускаем новую игру
+    document.getElementById('twoBtn').click();
   });
 
   test('canvas существует и имеет правильные размеры', () => {


### PR DESCRIPTION
## Summary
- expose game state to `window` so test code can inspect it
- make resetting state update `window.spawnZones`
- keep `window.spawnZones` synced when spawn mode changes
- allow right-click on canvas to cancel actions
- stabilize tests with jsdom setup and start a game automatically
- add minimal Jest configuration

## Testing
- `npm install jest jest-environment-jsdom jsdom text-encoding --no-save`
- `npx jest tests/core.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685a7acbfcc88332aad6c567a46e0c1d