### PR TITLE
UI and turn overlay tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -76,7 +76,7 @@ h1 {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background: rgba(0,0,0,0.7);
+  background: #000;
   color: #fff;
   font: 1.2em 'Lora', serif;
   z-index: 40;
@@ -192,4 +192,22 @@ h1 {
   padding: 8px;
   overflow-y: auto;
   font-family: 'Lora', serif;
+}
+
+@media (max-width: 600px) {
+  #statsLog {
+    flex-direction: column;
+  }
+  #leftStats {
+    border-right: none;
+    border-bottom: 1px solid #555;
+  }
+  #rightLog {
+    border-bottom: none;
+  }
+  #spawnPanel {
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 80%;
+  }
 }

--- a/js/core.js
+++ b/js/core.js
@@ -108,10 +108,10 @@ window.addEventListener('DOMContentLoaded',()=>{
   // === Resize & Fog init ===
   window.addEventListener('resize',()=>{
     const infoH = document.getElementById('infoPanel').offsetHeight;
-    canvas.width = window.innerWidth;
-    canvas.height= window.innerHeight - infoH;
-    cellW = canvas.width  / COLS;
-    cellH = canvas.height / ROWS;
+    cellW = Math.floor(window.innerWidth / COLS);
+    cellH = Math.floor((window.innerHeight - infoH) / ROWS);
+    canvas.width  = cellW * COLS;
+    canvas.height = cellH * ROWS;
     [1,2].forEach(p=>{
       state.fog[p]  = Array.from({length:ROWS},()=>Array(COLS).fill(true));
       state.seen[p] = Array.from({length:ROWS},()=>Array(COLS).fill(false));
@@ -268,9 +268,6 @@ window.addEventListener('DOMContentLoaded',()=>{
     if(sel&&sel.mp>0){
       ctx.fillStyle='rgba(255,255,255,0.3)';
       zoneList.forEach(z=>ctx.fillRect(z.c*cellW,z.r*cellH,cellW,cellH));
-      ctx.strokeStyle='#888'; ctx.lineWidth=1; ctx.setLineDash([4,4]);
-      zoneList.forEach(z=>ctx.strokeRect(z.c*cellW+1,z.r*cellH+1,cellW-2,cellH-2));
-      ctx.setLineDash([]);
     }
 
     // spawn zone


### PR DESCRIPTION
## Summary
- adjust canvas resizing to use integer cell sizes
- remove dashed grid lines from move preview
- darken turn overlay background
- add small-screen layout tweaks

## Testing
- `npx -y jest tests/core.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685aada1c3d883328f684b2835a8ffbc