### PR TITLE
Dark theme start screen with audio/video

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,6 +16,22 @@ h1 {
   margin-top: 0;
 }
 
+#bgVideo {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 10;
+}
+#bgVideo.fade-out {
+  animation: fadeOut 1s forwards;
+}
+@keyframes fadeOut {
+  to { opacity: 0; visibility: hidden; }
+}
+
 #startPanel {
   position: fixed;
   top: 0;
@@ -26,10 +42,11 @@ h1 {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background: #f7f4ef;
-  color: #2c291f;
+  background: radial-gradient(#222, #000);
+  color: #eee;
   font: 1.1em 'Lora', serif;
   z-index: 30;
+  text-shadow: 0 0 6px #000;
 }
 
 #summary {
@@ -37,20 +54,21 @@ h1 {
   height: 40%;
   margin-bottom: 20px;
   padding: 10px;
-  background: rgba(255,255,255,0.8);
-  border: 1px solid #c6b47a;
+  background: rgba(20,20,20,0.8);
+  border: 1px solid #555;
   overflow-y: auto;
   text-align: left;
+  color: #ddd;
   font-family: 'Lora', serif;
 }
 
 #startPanel button {
   margin: 6px;
   padding: 10px 20px;
-  background: #d8cfa9;
+  background: #444;
   border: none;
   border-radius: 4px;
-  color: #2e2e2e;
+  color: #eee;
   cursor: pointer;
   font-family: 'Lora', serif;
   font-weight: bold;
@@ -58,13 +76,13 @@ h1 {
 }
 
 #startPanel button:disabled {
-  background: #e4dbc2;
-  color: #777;
+  background: #666;
+  color: #999;
   cursor: default;
 }
 
 #startPanel button:hover:not(:disabled) {
-  background: #e1d7b9;
+  background: #666;
   transform: scale(1.05);
 }
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="css/style.css"/>
 </head>
 <body>
+  <video id="bgVideo" autoplay muted loop>
+    <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4"/>
+  </video>
+  <audio id="menuBgm" src="https://www.w3schools.com/html/horse.mp3" loop></audio>
   <div id="startPanel">
     <h1>Эпоха Тумана</h1>
     <div id="summary">

--- a/js/core.js
+++ b/js/core.js
@@ -19,7 +19,12 @@ window.addEventListener('DOMContentLoaded',()=>{
         revealBtn   = document.getElementById('revealBtn'),
         endTurnBtn  = document.getElementById('endTurnBtn'),
         leftStats   = document.getElementById('leftStats'),
-        rightLog    = document.getElementById('rightLog');
+        rightLog    = document.getElementById('rightLog'),
+        menuBgm     = document.getElementById('menuBgm'),
+        bgVideo     = document.getElementById('bgVideo');
+
+  menuBgm.volume = 0.5;
+  menuBgm.play().catch(()=>{});
 
   // === Константы ===
   const ROWS = 30, COLS = 20;
@@ -49,22 +54,34 @@ window.addEventListener('DOMContentLoaded',()=>{
         g.stroke();
       }
     });
-    TERR_PAT[TERRAIN.WATER] = pat('#87c8ff', g=>{
-      g.strokeStyle = 'rgba(90,160,224,0.5)';
+    TERR_PAT[TERRAIN.WATER] = pat('#5da9e9', g=>{
+      g.strokeStyle = 'rgba(255,255,255,0.3)';
       g.lineWidth = 1;
-      for(let y=8;y<=32;y+=8){
+      for(let y=4;y<32;y+=8){
         g.beginPath();
-        g.arc(16,y,14,0,Math.PI,false);
+        g.arc(16,y,12,0,Math.PI,false);
+        g.stroke();
+      }
+      g.strokeStyle = 'rgba(0,0,60,0.3)';
+      for(let y=8;y<32;y+=8){
+        g.beginPath();
+        g.arc(16,y+2,12,0,Math.PI,false);
         g.stroke();
       }
     });
-    TERR_PAT[TERRAIN.FOREST] = pat('#3c9a4c', g=>{
-      g.fillStyle = 'rgba(36,107,47,0.5)';
-      for(let x=-4;x<32;x+=8){
+    TERR_PAT[TERRAIN.FOREST] = pat('#2c7534', g=>{
+      g.fillStyle = 'rgba(20,50,20,0.6)';
+      for(let x=0;x<32;x+=8){
         g.beginPath();
-        g.moveTo(x+4,6);
+        g.moveTo(x+4,4);
         g.lineTo(x,16);
         g.lineTo(x+8,16);
+        g.closePath();
+        g.fill();
+        g.beginPath();
+        g.moveTo(x+4,12);
+        g.lineTo(x-2,24);
+        g.lineTo(x+10,24);
         g.closePath();
         g.fill();
       }
@@ -78,15 +95,23 @@ window.addEventListener('DOMContentLoaded',()=>{
         g.stroke();
       }
     });
-    TERR_PAT[TERRAIN.MOUNTAIN] = pat('#9a9a9a', g=>{
-      g.fillStyle = 'rgba(119,119,119,0.6)';
-      for(let x=0;x<=32;x+=16){
+    TERR_PAT[TERRAIN.MOUNTAIN] = pat('#787878', g=>{
+      g.fillStyle = 'rgba(130,130,130,0.7)';
+      for(let x=0;x<32;x+=16){
         g.beginPath();
-        g.moveTo(x,8);
-        g.lineTo(x-8,32);
-        g.lineTo(x+8,32);
+        g.moveTo(x+8,4);
+        g.lineTo(x,32);
+        g.lineTo(x+16,32);
         g.closePath();
         g.fill();
+        g.fillStyle = 'rgba(255,255,255,0.3)';
+        g.beginPath();
+        g.moveTo(x+8,4);
+        g.lineTo(x+4,16);
+        g.lineTo(x+12,16);
+        g.closePath();
+        g.fill();
+        g.fillStyle = 'rgba(130,130,130,0.7)';
       }
     });
   }
@@ -689,6 +714,8 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   // === Стартовые кнопки ===
   twoBtn.addEventListener('click',()=>{
+    menuBgm.pause();
+    bgVideo.classList.add('fade-out');
     resetState();
     modeBeta=false; revealBtn.style.display='none';
     startPanel.style.display='none';
@@ -696,6 +723,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     recordTurn(); updateAll();
   });
   betaBtn.addEventListener('click',()=>{
+    menuBgm.pause();
+    bgVideo.classList.add('fade-out');
     resetState();
     modeBeta=true; revealBtn.style.display='inline-block';
     startPanel.style.display='none';


### PR DESCRIPTION
## Summary
- restyle the start menu with a dark theme
- add background video and music
- improve mountain, forest and water terrain patterns
- fade out menu media on game start

## Testing
- `npx jest tests/core.test.js --runInBand` *(fails: needs jest package)*

------
https://chatgpt.com/codex/tasks/task_e_685ac461608c8332bc626f6ef9159bd2