### PR TITLE
Improve map generation fallback

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -322,11 +322,19 @@ window.addEventListener('DOMContentLoaded',()=>{
         count = Math.max(1,Math.round(count*scale));
         let half=count/2|0;
         for(let i=0;i<half;i++){
-          const p=freeCell(1);
+          let p=freeCell(1);
+          if(!p){
+            p = freeCell();
+            if(!p) console.warn(`Unable to place ${type} on side 1`);
+          }
           if(p) buildings.push({r:p.r,c:p.c,owner:0,type});
         }
         for(let i=0;i<count-half;i++){
-          const p=freeCell(2);
+          let p=freeCell(2);
+          if(!p){
+            p = freeCell();
+            if(!p) console.warn(`Unable to place ${type} on side 2`);
+          }
           if(p) buildings.push({r:p.r,c:p.c,owner:0,type});
         }
       });
@@ -352,7 +360,11 @@ window.addEventListener('DOMContentLoaded',()=>{
       if(buildings.some(b=>abs(b.r-r)+abs(b.c-c)<7)) continue;
       return {r,c};
     }
+    return null;
   }
+
+  // expose for tests
+  Object.assign(window, { freeCell });
 
   // === LOS ===
   function hasLOS(r0,c0,r1,c1,{forestBlock=true}={}){

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -64,4 +64,14 @@ describe('Fog of Conquest core', () => {
       expect(window.map[z.r][z.c]).not.toBe(window.TERRAIN.MOUNTAIN);
     });
   });
+
+  test('freeCell returns null on a nearly full map', () => {
+    const { map, TERRAIN, freeCell } = window;
+    for(let r=0; r<map.length; r++){
+      for(let c=0; c<map[r].length; c++){
+        map[r][c] = TERRAIN.MOUNTAIN;
+      }
+    }
+    expect(freeCell(1)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- place buildings more carefully in `generateMap`
- return `null` from `freeCell` when no spot is found and expose for tests
- add a regression test for full-map edge case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3c6086008332beec6a2dade9d39d