### PR TITLE
Add mobile-friendly overlays and legend

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,7 +6,7 @@ html, body {
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #000;
+  background: radial-gradient(#111, #000);
   color: #2e2e2e;
   font-family: 'MedievalSharp', cursive;
 }
@@ -164,7 +164,7 @@ h1 {
   display: none;
   align-items: center;
   justify-content: center;
-  background: #000;
+  background: rgba(0, 0, 0, 0.5);
   color: #fff;
   font: 2em 'MedievalSharp', cursive;
   z-index: 45;
@@ -293,4 +293,60 @@ h1 {
     transform: translateX(-50%);
     max-width: 80%;
   }
+}
+
+#legendBtn {
+  margin-left: 8px;
+  padding: 6px 10px;
+}
+
+#legendOverlay,
+#victoryOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font: 1.2em 'Lora', serif;
+  z-index: 50;
+  text-align: center;
+}
+
+#legendOverlay .panel,
+#victoryOverlay .panel {
+  background: #222;
+  padding: 20px;
+  border: 1px solid #555;
+  border-radius: 6px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  margin: 4px 0;
+}
+
+.legendColor {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  margin-right: 6px;
+}
+
+#legendOverlay button,
+#victoryOverlay button {
+  margin-top: 10px;
+  padding: 6px 12px;
+  background: #bda46a;
+  border: none;
+  border-radius: 4px;
+  color: #2e2e2e;
+  cursor: pointer;
+  font: 1em 'Lora', serif;
+  font-weight: bold;
 }

--- a/index.html
+++ b/index.html
@@ -66,12 +66,25 @@
 
   <div id="waitOverlay">Подождите...</div>
 
+  <div id="victoryOverlay">
+    <div class="panel">
+      <div id="victoryText"></div>
+      <button id="victoryOkBtn">Ок</button>
+    </div>
+  </div>
+
+  <div id="legendOverlay">
+    <div class="panel" id="legendPanel"></div>
+    <button id="legendCloseBtn">Закрыть</button>
+  </div>
+
   <canvas id="canvas"></canvas>
 
   <div id="spawnPanel"></div>
 
   <div id="infoPanel">
     <div id="controls">
+      <button id="legendBtn" title="Легенда">ℹ️</button>
       <button id="revealBtn">Показать карту</button>
       <button id="endTurnBtn">Конец хода</button>
     </div>

--- a/js/core.js
+++ b/js/core.js
@@ -18,6 +18,13 @@ window.addEventListener('DOMContentLoaded',()=>{
         ctx         = canvas.getContext('2d'),
         spawnPanel  = document.getElementById('spawnPanel'),
         revealBtn   = document.getElementById('revealBtn'),
+        legendBtn   = document.getElementById('legendBtn'),
+        legendOverlay = document.getElementById('legendOverlay'),
+        legendPanel = document.getElementById('legendPanel'),
+        legendCloseBtn = document.getElementById('legendCloseBtn'),
+        victoryOverlay = document.getElementById('victoryOverlay'),
+        victoryText = document.getElementById('victoryText'),
+        victoryOkBtn = document.getElementById('victoryOkBtn'),
         endTurnBtn  = document.getElementById('endTurnBtn'),
         leftStats   = document.getElementById('leftStats'),
         rightLog    = document.getElementById('rightLog'),
@@ -165,6 +172,13 @@ window.addEventListener('DOMContentLoaded',()=>{
     fort:'🏯'
   };
 
+  function setupLegend(){
+    legendPanel.innerHTML = Object.entries(UNIT_TYPES)
+      .filter(([t])=>t!=='bog')
+      .map(([t])=>`<div class="legendItem"><span class="legendColor" style="background:${UNIT_TYPES[t].color}"></span>${UNIT_LABELS[t]}</div>`)
+      .join('');
+  }
+
   // === Состояние ===
   let modeBeta = false,
       revealAll = false,
@@ -200,6 +214,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   function recordEvent(txt){
     const p = state.currentPlayer;
     state.log[p].push(txt);
+    if(aiMode && p===2) state.log[1].push('Враг: '+txt);
     renderLog();
   }
   function recordTurn(){
@@ -639,7 +654,8 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   function endGame(w){
     gameOver=true;
-    setTimeout(()=>alert(`Игрок ${w} победил!`),100);
+    victoryText.textContent = `Игрок ${w} победил!`;
+    victoryOverlay.style.display = 'flex';
   }
 
   // === updateLeft ===
@@ -692,6 +708,7 @@ window.addEventListener('DOMContentLoaded',()=>{
         units.push({id:nextUnitId++,r:z.r,c:z.c,owner:p,type,hp:UNIT_TYPES[type].hpMax,mp:0,startR:z.r,startC:z.c});
         state.gold[p]-=UNIT_TYPES[type].cost;
         addReplay({type:'spawn',unit:units[units.length-1]});
+        recordEvent(`Создан ${UNIT_LABELS[type]}`);
       }
     });
 
@@ -704,6 +721,7 @@ window.addEventListener('DOMContentLoaded',()=>{
           if(map[u.r][u.c]!==TERRAIN.WATER){
             const res=doAttack(u,enemy);
             addReplay({type:'attack',target:enemy});
+            recordEvent(`${UNIT_LABELS[u.type]} атаковал ${UNIT_LABELS[enemy.type]}`);
             if(res.killed && UNIT_TYPES[u.type].range===1){
               addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:enemy.r,c:enemy.c}});
               u.r=enemy.r; u.c=enemy.c;
@@ -756,8 +774,13 @@ window.addEventListener('DOMContentLoaded',()=>{
         if(target){
           u.mp=cz.rem[target.r][target.c];
           let bb=buildings.find(b=>b.r===target.r&&b.c===target.c&&b.owner!==p);
-          if(bb){ bb.owner=p; addReplay({type:'capture',building:bb}); }
+          if(bb){
+            bb.owner=p;
+            addReplay({type:'capture',building:bb});
+            recordEvent(`Захвачено ${BUILD_LABELS[bb.type]}`);
+          }
           addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:target.r,c:target.c}});
+          recordEvent(`${UNIT_LABELS[u.type]} переместился`);
           u.r=target.r; u.c=target.c;
         } else break;
       }
@@ -915,6 +938,7 @@ window.addEventListener('DOMContentLoaded',()=>{
       overlay.style.display='none';
       if(aiMode){
         fogSnapshot = state.fog[1].map(r=>r.slice());
+        waitOverlay.textContent = 'Ход противника...';
         waitOverlay.style.display='flex';
         nextTurn();
         aiTakeTurn();
@@ -926,6 +950,15 @@ window.addEventListener('DOMContentLoaded',()=>{
   });
   yesBtn.addEventListener('click',()=>{ overlay.style.display='none'; continueAfter&&continueAfter(); });
   noBtn.addEventListener('click',()=>{ overlay.style.display='none'; });
+
+  legendBtn.addEventListener('click',()=>{ legendOverlay.style.display='flex'; });
+  legendCloseBtn.addEventListener('click',()=>{ legendOverlay.style.display='none'; });
+  victoryOkBtn.addEventListener('click',()=>{
+    victoryOverlay.style.display='none';
+    startPanel.style.display='flex';
+    menuBgm.currentTime = 0;
+    menuBgm.play();
+  });
 
   // === Туман войны (бета) ===
   revealBtn.addEventListener('click',()=>{
@@ -1037,5 +1070,6 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   // === Инициализация ===
   makePatterns();
+  setupLegend();
   window.dispatchEvent(new Event('resize'));
 });


### PR DESCRIPTION
## Summary
- improve base background and make wait overlay semi-transparent
- add legend and victory overlays
- support legend button in controls
- show enemy actions during AI turns via recordEvent updates
- display victory message in overlay instead of alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4364979c83329a2483db5c079be8