### PR TITLE
Handle fog for AI logic

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -206,7 +206,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   let nextUnitId = 1;
 
   // expose for tests
-  Object.assign(window, { map, buildings, units, TERRAIN, UNIT_TYPES, BUILD_TYPES });
+  Object.assign(window, { map, buildings, units, state, TERRAIN, UNIT_TYPES, BUILD_TYPES });
 
   let cellW, cellH;
 
@@ -379,7 +379,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   }
 
   // expose for tests
-  Object.assign(window, { freeCell });
+  Object.assign(window, { freeCell, aiTakeTurn });
 
   // === LOS ===
   function hasLOS(r0,c0,r1,c1,{forestBlock=true}={}){
@@ -688,9 +688,10 @@ window.addEventListener('DOMContentLoaded',()=>{
   }
 
   function aiTakeTurn(){
-    const p=2;
-    const enemyUnits=units.filter(u=>u.owner===1);
-    const enemyBuildings=buildings.filter(b=>b.owner===1);
+    const p=2,
+          F=state.fog[p];
+    const enemyUnits=units.filter(u=>u.owner===1 && !F[u.r][u.c]);
+    const enemyBuildings=buildings.filter(b=>b.owner===1 && !F[b.r][b.c]);
     const enemyBases=enemyBuildings.filter(b=>BUILD_TYPES[b.type].gen===0);
     const baseDist=enemyBases.length?computeDistanceMap(enemyBases):null;
     const buildDist=enemyBuildings.length?computeDistanceMap(enemyBuildings):null;
@@ -714,7 +715,7 @@ window.addEventListener('DOMContentLoaded',()=>{
 
     units.filter(u=>u.owner===p).forEach(u=>{
       while(u.mp>0){
-        const enemy=units.find(t=>t.owner===1 &&
+        const enemy=units.find(t=>t.owner===1 && !F[t.r][t.c] &&
           Math.abs(t.r-u.r)+Math.abs(t.c-u.c)<=UNIT_TYPES[u.type].range &&
           hasLOS(u.r,u.c,t.r,t.c,{forestBlock:false}));
         if(enemy){
@@ -786,6 +787,7 @@ window.addEventListener('DOMContentLoaded',()=>{
       }
     });
 
+    updateFog();
     nextTurn();
   }
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -26,6 +26,11 @@ describe('Fog of Conquest core', () => {
     const dom = new JSDOM(html, { runScripts: "dangerously", resources: "usable", url: `file://${process.cwd()}/index.html` });
     document = dom.window.document;
     window = dom.window;
+    window.HTMLCanvasElement.prototype.getContext = () => ({
+      fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
+      stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
+      moveTo:()=>{}, lineTo:()=>{}
+    });
 
     await new Promise(res => {
       document.addEventListener('DOMContentLoaded', () => {
@@ -73,5 +78,29 @@ describe('Fog of Conquest core', () => {
       }
     }
     expect(freeCell(1)).toBeNull();
+  });
+
+  test('AI ignores units hidden by fog', () => {
+    const { state, units, aiTakeTurn, UNIT_TYPES } = window;
+    const aiUnit = units.find(u => u.owner === 2);
+    const enemy = units.find(u => u.owner === 1);
+    enemy.r = aiUnit.r;
+    enemy.c = aiUnit.c + 1;
+
+    if(!state.fog[2]){
+      const rows = window.map.length;
+      const cols = window.map[0].length;
+      state.fog[2]  = Array.from({length:rows},()=>Array(cols).fill(true));
+      state.seen[2] = Array.from({length:rows},()=>Array(cols).fill(false));
+    }
+    state.fog[2].forEach((row, r) => row.forEach((_, c) => {
+      state.fog[2][r][c] = true;
+      state.seen[2][r][c] = false;
+    }));
+    state.fog[2][aiUnit.r][aiUnit.c] = false;
+
+    const hpBefore = enemy.hp;
+    aiTakeTurn();
+    expect(enemy.hp).toBe(hpBefore);
   });
 });


### PR DESCRIPTION
## Summary
- expose `state` and `aiTakeTurn`
- teach `aiTakeTurn` to respect player 2 fog
- keep fog updated after AI moves
- add unit test to ensure hidden units aren't targeted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5a6264448332a3564e6baba3fab2