### PR TITLE
Improve AI unit selection

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -696,6 +696,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     const baseDist=enemyBases.length?computeDistanceMap(enemyBases):null;
     const buildDist=enemyBuildings.length?computeDistanceMap(enemyBuildings):null;
     const unitDist=enemyUnits.length?computeDistanceMap(enemyUnits):null;
+    const enemyCounts={};
+    enemyUnits.forEach(u=>enemyCounts[u.type]=(enemyCounts[u.type]||0)+1);
     // спавн
     buildings.filter(b=>b.owner===p && BUILD_TYPES[b.type].spawn.length).forEach(b=>{
       const avail=BUILD_TYPES[b.type].spawn.filter(t=>UNIT_TYPES[t].cost<=state.gold[p]);
@@ -704,7 +706,16 @@ window.addEventListener('DOMContentLoaded',()=>{
                map[z.r][z.c]!==TERRAIN.MOUNTAIN&&
                !units.find(u=>u.r===z.r&&u.c===z.c));
       if(avail.length&&zones.length){
-        const type=avail[0];
+        let best=null,bestScore=-Infinity;
+        avail.forEach(t=>{
+          const info=UNIT_TYPES[t];
+          const base=info.atk+info.def+info.range;
+          const goldFactor=state.gold[p]/info.cost;
+          const compFactor=(enemyCounts[t]||0)*2;
+          const score=base+goldFactor+compFactor;
+          if(score>bestScore){ bestScore=score; best=t; }
+        });
+        const type=best;
         const z=zones[Math.random()*zones.length|0];
         units.push({id:nextUnitId++,r:z.r,c:z.c,owner:p,type,hp:UNIT_TYPES[type].hpMax,mp:0,startR:z.r,startC:z.c});
         state.gold[p]-=UNIT_TYPES[type].cost;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -103,4 +103,42 @@ describe('Fog of Conquest core', () => {
     aiTakeTurn();
     expect(enemy.hp).toBe(hpBefore);
   });
+
+  test('AI spawns counter unit based on enemy composition', () => {
+    const { state, units, aiTakeTurn } = window;
+    document.getElementById('twoBtn').click();
+    state.currentPlayer = 2;
+    state.gold[2] = 3;
+    const rows = window.map.length, cols = window.map[0].length;
+    state.fog[2] = Array.from({length:rows},()=>Array(cols).fill(false));
+    state.seen[2] = Array.from({length:rows},()=>Array(cols).fill(true));
+    units.filter(u=>u.owner===2).forEach(u=>units.splice(units.indexOf(u),1));
+    units.filter(u=>u.owner===1 && u.type==='swordsman').forEach(u=>units.splice(units.indexOf(u),1));
+    const countBefore = units.length;
+    aiTakeTurn();
+    const spawned = units.find((u,i)=>i>=countBefore && u.owner===2);
+    expect(spawned.type).toBe('archer');
+  });
+
+  test('AI prefers expensive unit when affordable', () => {
+    const { state, units, BUILD_TYPES, aiTakeTurn, UNIT_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    const original = [...BUILD_TYPES.base.spawn];
+    BUILD_TYPES.base.spawn = ['swordsman','heavy'];
+    const enemy = units.find(u=>u.owner===1);
+    enemy.type = 'heavy';
+    enemy.hp = UNIT_TYPES.heavy.hpMax;
+    enemy.mp = UNIT_TYPES.heavy.move;
+    units.filter(u=>u.owner===2).forEach(u=>units.splice(units.indexOf(u),1));
+    state.currentPlayer = 2;
+    state.gold[2] = 5;
+    const rows = window.map.length, cols = window.map[0].length;
+    state.fog[2] = Array.from({length:rows},()=>Array(cols).fill(false));
+    state.seen[2] = Array.from({length:rows},()=>Array(cols).fill(true));
+    const countBefore = units.length;
+    aiTakeTurn();
+    const spawned = units.find((u,i)=>i>=countBefore && u.owner===2);
+    expect(spawned.type).toBe('heavy');
+    BUILD_TYPES.base.spawn = original;
+  });
 });


### PR DESCRIPTION
## Summary
- tune `aiTakeTurn` spawning to consider enemy composition, gold and unit cost
- test AI unit choice with different gold levels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5d83e55083329ceca54e6fb4b83d