### PR TITLE
Improve AI pathfinding with terrain costs

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -379,7 +379,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   }
 
   // expose for tests
-  Object.assign(window, { freeCell, aiTakeTurn });
+  Object.assign(window, { freeCell, aiTakeTurn, computeDistanceMap });
 
   // === LOS ===
   function hasLOS(r0,c0,r1,c1,{forestBlock=true}={}){
@@ -586,16 +586,17 @@ window.addEventListener('DOMContentLoaded',()=>{
   function computeDistanceMap(targets){
     const dist=Array.from({length:ROWS},()=>Array(COLS).fill(Infinity));
     const q=[];
-    targets.forEach(t=>{ dist[t.r][t.c]=0; q.push({r:t.r,c:t.c}); });
+    targets.forEach(t=>{ dist[t.r][t.c]=0; q.push({r:t.r,c:t.c,d:0}); });
     while(q.length){
+      q.sort((a,b)=>a.d-b.d);
       const o=q.shift();
       const d=dist[o.r][o.c];
       [[1,0],[-1,0],[0,1],[0,-1]].forEach(([dr,dc])=>{
         const rr=o.r+dr, cc=o.c+dc;
         if(rr<0||rr>=ROWS||cc<0||cc>=COLS) return;
         if(map[rr][cc]===TERRAIN.MOUNTAIN) return;
-        const nd=d+1;
-        if(nd<dist[rr][cc]){ dist[rr][cc]=nd; q.push({r:rr,c:cc}); }
+        const nd=d+TERR_COST[map[rr][cc]];
+        if(nd<dist[rr][cc]){ dist[rr][cc]=nd; q.push({r:rr,c:cc,d:nd}); }
       });
     }
     return dist;
@@ -696,6 +697,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     const baseDist=enemyBases.length?computeDistanceMap(enemyBases):null;
     const buildDist=enemyBuildings.length?computeDistanceMap(enemyBuildings):null;
     const unitDist=enemyUnits.length?computeDistanceMap(enemyUnits):null;
+    const allEnemies=[...enemyUnits,...enemyBuildings];
+    const allDist=allEnemies.length?computeDistanceMap(allEnemies):null;
     const enemyCounts={};
     enemyUnits.forEach(u=>enemyCounts[u.type]=(enemyCounts[u.type]||0)+1);
     // спавн
@@ -748,18 +751,8 @@ window.addEventListener('DOMContentLoaded',()=>{
         if(aiLevel===1){
           target=cz.list[Math.random()*cz.list.length|0];
         }else if(aiLevel===2){
-          const enemies=[...units.filter(e=>e.owner===1),...buildings.filter(b=>b.owner===1)];
-          if(enemies.length){
-            const trg=enemies.reduce((a,b)=>{
-              const da=Math.abs(a.r-u.r)+Math.abs(a.c-u.c);
-              const db=Math.abs(b.r-u.r)+Math.abs(b.c-u.c);
-              return da<db?a:b;
-            });
-            target=cz.list.sort((a,b)=>{
-              const da=Math.abs(a.r-trg.r)+Math.abs(a.c-trg.c);
-              const db=Math.abs(b.r-trg.r)+Math.abs(b.c-trg.c);
-              return da-db;
-            })[0];
+          if(allDist){
+            target=cz.list.sort((a,b)=>allDist[a.r][a.c]-allDist[b.r][b.c])[0];
           } else target=cz.list[0];
         }else{
           let best=null,bestScore=-Infinity;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -141,4 +141,36 @@ describe('Fog of Conquest core', () => {
     expect(spawned.type).toBe('heavy');
     BUILD_TYPES.base.spawn = original;
   });
+
+  test('computeDistanceMap accounts for terrain cost', () => {
+    const { map, TERRAIN, computeDistanceMap } = window;
+    document.getElementById('twoBtn').click();
+    for(let r=0;r<2;r++)for(let c=0;c<5;c++) map[r][c]=TERRAIN.PLAIN;
+    map[0][1]=TERRAIN.WATER;
+    map[0][2]=TERRAIN.WATER;
+    map[0][3]=TERRAIN.WATER;
+    const dist = computeDistanceMap([{r:0,c:4}]);
+    expect(dist[0][0]).toBe(6);
+  });
+
+  test('AI avoids high-cost terrain when possible', () => {
+    const { map, TERRAIN, units, buildings, state, aiTakeTurn, UNIT_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    units.length = 0;
+    buildings.length = 0;
+    for(let r=0;r<2;r++)for(let c=0;c<5;c++) map[r][c]=TERRAIN.PLAIN;
+    map[0][1]=TERRAIN.WATER;
+    map[0][2]=TERRAIN.WATER;
+    map[0][3]=TERRAIN.WATER;
+    buildings.push({r:0,c:4,owner:1,type:'base'});
+    units.push({id:1,r:0,c:0,owner:2,type:'swordsman',hp:UNIT_TYPES.swordsman.hpMax,mp:UNIT_TYPES.swordsman.move,startR:0,startC:0});
+    state.currentPlayer = 2;
+    const rows = map.length, cols = map[0].length;
+    state.fog[2] = Array.from({length:rows},()=>Array(cols).fill(false));
+    state.seen[2] = Array.from({length:rows},()=>Array(cols).fill(true));
+    const u = units[0];
+    aiTakeTurn();
+    expect(u.r).toBe(1);
+    expect(u.c).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- account for terrain costs in `computeDistanceMap`
- have the AI favour cheaper routes using cost-aware distances
- expose `computeDistanceMap` for tests
- test that distance maps and AI movement avoid costly terrain

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6268af248332a7b0216bd81d594f