### PR TITLE
Preserve selection after move and attack

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -766,7 +766,12 @@ window.addEventListener('DOMContentLoaded',()=>{
           }
           recordEvent(`${UNIT_LABELS[sel.type]} атаковал ${UNIT_LABELS[tgt.type]} за ${dmg}`+
                       (rdmg?`, получил ${rdmg}`:''));
-          sel=null; zoneMap=null; zoneList=[]; updateAll(); return;
+          if(sel.mp>0){
+            let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list;
+          } else {
+            sel=null; zoneMap=null; zoneList=[];
+          }
+          updateAll(); return;
         }
         if(zoneMap.rem[y][x]>=0 && !units.find(u=>u.r===y&&u.c===x)){
           sel.mp=zoneMap.rem[y][x];
@@ -781,7 +786,12 @@ window.addEventListener('DOMContentLoaded',()=>{
           animateMove(sel,sel.r,sel.c,y,x);
           sel.r=y; sel.c=x;
           if(moved) recordEvent(`Перемещён ${UNIT_LABELS[sel.type]}`);
-          sel=null; zoneMap=null; zoneList=[]; updateAll(); return;
+          if(sel.mp>0){
+            let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list;
+          } else {
+            sel=null; zoneMap=null; zoneList=[];
+          }
+          updateAll(); return;
         }
       }
       sel=null; zoneMap=null; zoneList=[]; updateAll(); return;


### PR DESCRIPTION
## Summary
- keep unit selected if it still has movement after acting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d1d54f52483329bbc99b219d418a3