### PR TITLE
Fix AI replay cleanup and add fog reset test

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -192,7 +192,8 @@ window.addEventListener('DOMContentLoaded',()=>{
       spawnMode = false, spawnType = null, spawnZones = [],
       continueAfter = null,
       fogSnapshot = null,
-      aiReplay = [];
+      aiReplay = [],
+      aiReplayTimeouts = [];
 
   Object.assign(window, { spawnZones });
 
@@ -276,6 +277,9 @@ window.addEventListener('DOMContentLoaded',()=>{
   function resetState(){
     gameOver = false;
     revealAll = false;
+    aiReplayTimeouts.forEach(id=>clearTimeout(id));
+    aiReplayTimeouts.length=0;
+    aiReplay = [];
     sel = null;
     zoneMap = null; zoneList = [];
     spawnMode = false; spawnType = null; spawnZones = [];
@@ -426,6 +430,11 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   // === Fog ===
   function updateFog(){
+    if(state.turn===0){
+      const p=state.currentPlayer, F=state.fog[p];
+      for(let r=0;r<ROWS;r++)for(let c=0;c<COLS;c++)F[r][c]=true;
+      return;
+    }
     if(!modeBeta && !revealAll){
       const p=state.currentPlayer, F=state.fog[p], S=state.seen[p];
       for(let r=0;r<ROWS;r++)for(let c=0;c<COLS;c++)F[r][c]=true;
@@ -939,6 +948,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   }
 
   function replayAI(){
+    aiReplayTimeouts.length = 0;
     let i=0;
     const run=()=>{
       if(i>=aiReplay.length){
@@ -951,12 +961,12 @@ window.addEventListener('DOMContentLoaded',()=>{
       const ev=aiReplay[i++];
       if(ev.type==='move'){
         animateMove(ev.unit,ev.from.r,ev.from.c,ev.to.r,ev.to.c);
-        setTimeout(run,300);
+        aiReplayTimeouts.push(setTimeout(run,300));
       }else if(ev.type==='attack'){
         animateShake(ev.target);
-        setTimeout(run,150);
+        aiReplayTimeouts.push(setTimeout(run,150));
       }else{
-        setTimeout(run,250);
+        aiReplayTimeouts.push(setTimeout(run,250));
       }
       redraw();
     };

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -184,4 +184,13 @@ describe('Fog of Conquest core', () => {
     nextTurn();
     expect(state.gold[2]).toBe(7);
   });
+
+  test('twoBtn click twice resets fog arrays', () => {
+    const btn = document.getElementById('twoBtn');
+    btn.click();
+    btn.click();
+    const { fog } = window.state;
+    const allClear = [1,2].every(p => fog[p].every(row => row.every(cell => cell === true)));
+    expect(allClear).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- track timeout IDs in `replayAI`
- clear pending timeouts and reset `aiReplay` when resetting state
- skip fog updates on the initial turn so fog arrays stay `true`
- test that starting a new game twice fully resets fog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5076697483329618796acb51c4f6