### PR TITLE
Fix building capture on kill

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -135,6 +135,12 @@
             if(res.killed && UNIT_TYPES[u.type].range===1){
               global.addReplay && global.addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:enemy.r,c:enemy.c}});
               u.r=enemy.r; u.c=enemy.c;
+              let bb=buildings.find(b=>b.r===u.r&&b.c===u.c&&b.owner!==p);
+              if(bb){
+                bb.owner=p;
+                global.addReplay && global.addReplay({type:'capture',building:bb});
+                global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
+              }
             }
           }
           u.mp=0;

--- a/js/core.js
+++ b/js/core.js
@@ -778,6 +778,14 @@ window.addEventListener('DOMContentLoaded',()=>{
           if(killed && UNIT_TYPES[sel.type].range===1){
             animateMove(sel,sel.r,sel.c,tgt.r,tgt.c);
             sel.r=tgt.r; sel.c=tgt.c;
+            let bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c&&b.owner!==p);
+            if(bb){
+              const baseTaken = (bb.gen ?? BUILD_TYPES[bb.type].gen)===0;
+              recordEvent(baseTaken
+                ? `Захвачена база`
+                : `Захвачена добыча (${BUILD_LABELS[bb.type]})`);
+              bb.owner=p;
+            }
           }
           recordEvent(`${UNIT_LABELS[sel.type]} атаковал ${UNIT_LABELS[tgt.type]} за ${dmg}`+
                       (rdmg?`, получил ${rdmg}`:''));

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -26,6 +26,10 @@ describe('Fog of Conquest core', () => {
     const dom = new JSDOM(html, { runScripts: "dangerously", resources: "usable", url: `file://${process.cwd()}/index.html` });
     document = dom.window.document;
     window = dom.window;
+    global.requestAnimationFrame = cb => setTimeout(cb,0);
+    global.cancelAnimationFrame = id => clearTimeout(id);
+    window.requestAnimationFrame = global.requestAnimationFrame;
+    window.cancelAnimationFrame = global.cancelAnimationFrame;
     window.HTMLCanvasElement.prototype.getContext = () => ({
       fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
       stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
@@ -183,5 +187,27 @@ describe('Fog of Conquest core', () => {
     state.currentPlayer = 1;
     nextTurn();
     expect(state.gold[2]).toBe(7);
+  });
+
+  test('building is captured when defender dies on it', () => {
+    const { map, TERRAIN, buildings, units, state, BUILD_TYPES, UNIT_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    units.length = 0;
+    buildings.length = 0;
+    for(let r=0;r<3;r++)for(let c=0;c<3;c++) map[r][c]=TERRAIN.PLAIN;
+    buildings.push({r:0,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen});
+    units.push({id:1,r:0,c:0,owner:2,type:'swordsman',hp:UNIT_TYPES.swordsman.hpMax,mp:UNIT_TYPES.swordsman.move,startR:0,startC:0});
+    units.push({id:2,r:0,c:1,owner:1,type:'swordsman',hp:1,mp:UNIT_TYPES.swordsman.move,startR:0,startC:1});
+    state.currentPlayer = 2;
+    const canvas = document.getElementById('canvas');
+    canvas.getBoundingClientRect = () => ({left:0,top:0,width:canvas.width,height:canvas.height});
+    const cellW = canvas.width / map[0].length;
+    const cellH = canvas.height / map.length;
+    function clickCell(r,c){
+      canvas.dispatchEvent(new window.MouseEvent('click',{clientX:(c+0.5)*cellW,clientY:(r+0.5)*cellH}));
+    }
+    clickCell(0,0);
+    clickCell(0,1);
+    expect(buildings[0].owner).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- capture buildings after killing a defender with melee attacks
- ensure AI also captures buildings after killing
- test building capture when defender dies on a building

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d697fed948332818df57ccdff6c11