### PR TITLE
Update move indicator color to white

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -574,7 +574,7 @@ window.addEventListener('DOMContentLoaded',()=>{
         ctx.fillStyle=u.owner===p?'#0f0':'#f00';
         ctx.fillRect(bx,by,w*frac,h);
         if(u.mp>0){
-          ctx.fillStyle='#00f';
+          ctx.fillStyle='#fff';
           ctx.beginPath();
           ctx.arc(cx,cy,rad*0.3,0,2*Math.PI);
           ctx.fill();


### PR DESCRIPTION
## Summary
- show remaining move indicator in white instead of blue

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d6b1e62b08332a381d5b8c49880fe