### PR TITLE
Add building HP and capture mechanics

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -137,9 +137,15 @@
               u.r=enemy.r; u.c=enemy.c;
               let bb=buildings.find(b=>b.r===u.r&&b.c===u.c&&b.owner!==p);
               if(bb){
-                bb.owner=p;
-                global.addReplay && global.addReplay({type:'capture',building:bb});
-                global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
+                global.damageBuilding ? global.damageBuilding(bb,p)
+                                      : (bb.owner=p);
+                if(global.damageBuilding){
+                  if(bb.owner===p)
+                    global.addReplay && global.addReplay({type:'capture',building:bb});
+                } else {
+                  global.addReplay && global.addReplay({type:'capture',building:bb});
+                  global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
+                }
               }
             }
           }
@@ -245,9 +251,15 @@
           u.mp-=moveCost;
           let bb=buildings.find(b=>b.r===target.r&&b.c===target.c&&b.owner!==p);
           if(bb){
-            bb.owner=p;
-            global.addReplay && global.addReplay({type:'capture',building:bb});
-            global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
+            global.damageBuilding ? global.damageBuilding(bb,p)
+                                  : (bb.owner=p);
+            if(global.damageBuilding){
+              if(bb.owner===p)
+                global.addReplay && global.addReplay({type:'capture',building:bb});
+            } else {
+              global.addReplay && global.addReplay({type:'capture',building:bb});
+              global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
+            }
           }
           global.addReplay && global.addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:target.r,c:target.c}});
           global.recordEvent && global.recordEvent(`${global.UNIT_LABELS[u.type]} переместился`);

--- a/js/core.js
+++ b/js/core.js
@@ -140,14 +140,14 @@ window.addEventListener('DOMContentLoaded',()=>{
   };
 
   const BUILD_TYPES = {
-    base:      {spawn:['swordsman','archer'],gen:0,def:1},
-    barracks:  {spawn:['heavy'],gen:0,def:0},
-    stable:    {spawn:['cavalry'],gen:0,def:0},
-    mageTower: {spawn:['mage'],gen:0,def:0},
+    base:      {spawn:['swordsman','archer'],gen:0,def:1,hpMax:2},
+    barracks:  {spawn:['heavy'],gen:0,def:0,hpMax:2},
+    stable:    {spawn:['cavalry'],gen:0,def:0,hpMax:2},
+    mageTower: {spawn:['mage'],gen:0,def:0,hpMax:2},
     // genUp указывает доход после улучшения
-    mine:      {spawn:[],gen:1,genUp:2,def:0},
-    lumber:    {spawn:[],gen:1,genUp:2,def:0},
-    fort:      {spawn:[],gen:0,def:2}
+    mine:      {spawn:[],gen:1,genUp:2,def:0,hpMax:2},
+    lumber:    {spawn:[],gen:1,genUp:2,def:0,hpMax:2},
+    fort:      {spawn:[],gen:0,def:2,hpMax:2}
   };
 
   const UNIT_LABELS = {
@@ -329,15 +329,15 @@ window.addEventListener('DOMContentLoaded',()=>{
     });
 
     // базы
-    buildings.push({r:1,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen});
-    buildings.push({r:ROWS-2,c:COLS-2,owner:2,type:'base',gen:BUILD_TYPES.base.gen});
+    buildings.push({r:1,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen,hp:BUILD_TYPES.base.hpMax});
+    buildings.push({r:ROWS-2,c:COLS-2,owner:2,type:'base',gen:BUILD_TYPES.base.gen,hp:BUILD_TYPES.base.hpMax});
 
     function addRes(owner,type){
       const b=buildings.find(x=>x.owner===owner&&x.type==='base');
       [[1,0],[-1,0],[0,1],[0,-1]].some(([dr,dc])=>{
         let rr=b.r+dr, cc=b.c+dc;
         if(rr>=0&&rr<ROWS&&cc>=0&&cc<COLS&&map[rr][cc]===TERRAIN.PLAIN){
-          buildings.push({r:rr,c:cc,owner,type,gen:BUILD_TYPES[type].gen});
+          buildings.push({r:rr,c:cc,owner,type,gen:BUILD_TYPES[type].gen,hp:BUILD_TYPES[type].hpMax});
           return true;
         }
       });
@@ -356,7 +356,7 @@ window.addEventListener('DOMContentLoaded',()=>{
             p = freeCell();
             if(!p) console.warn(`Unable to place ${type} on side 1`);
           }
-          if(p) buildings.push({r:p.r,c:p.c,owner:0,type,gen:BUILD_TYPES[type].gen});
+          if(p) buildings.push({r:p.r,c:p.c,owner:0,type,gen:BUILD_TYPES[type].gen,hp:BUILD_TYPES[type].hpMax});
         }
         for(let i=0;i<count-half;i++){
           let p=freeCell(2);
@@ -364,7 +364,7 @@ window.addEventListener('DOMContentLoaded',()=>{
             p = freeCell();
             if(!p) console.warn(`Unable to place ${type} on side 2`);
           }
-          if(p) buildings.push({r:p.r,c:p.c,owner:0,type,gen:BUILD_TYPES[type].gen});
+          if(p) buildings.push({r:p.r,c:p.c,owner:0,type,gen:BUILD_TYPES[type].gen,hp:BUILD_TYPES[type].hpMax});
         }
       });
 
@@ -401,7 +401,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     addReplay,
     updateFog,
     nextTurn,
-    recordEvent
+    recordEvent,
+    damageBuilding
   });
 
   // === LOS ===
@@ -528,6 +529,13 @@ window.addEventListener('DOMContentLoaded',()=>{
           ctx.strokeRect(b.c*cellW,b.r*cellH,cellW,cellH);
           ctx.setLineDash([]);
         }
+        let bw=cellW*0.6, bh=cellH*0.08,
+            bx=b.c*cellW+(cellW-bw)/2,
+            by=b.r*cellH+cellH*0.05;
+        ctx.fillStyle='#600'; ctx.fillRect(bx,by,bw,bh);
+        let frac=b.hp/BUILD_TYPES[b.type].hpMax;
+        ctx.fillStyle=b.owner===p?'#0f0':'#f00';
+        ctx.fillRect(bx,by,bw*frac,bh);
       }
     });
 
@@ -659,6 +667,19 @@ window.addEventListener('DOMContentLoaded',()=>{
     if(def.hp<=0&&def.type!=='bog'){ units.splice(units.indexOf(def),1); killed=true; }
     if(att.hp<=0&&att.type!=='bog') units.splice(units.indexOf(att),1);
     return {dmg,rdmg,killed};
+  }
+
+  function damageBuilding(b, newOwner){
+    if(!b) return;
+    b.hp--;
+    if(b.hp<=0){
+      const baseTaken=(b.gen ?? BUILD_TYPES[b.type].gen)===0;
+      recordEvent(baseTaken
+        ? `Захвачена база`
+        : `Захвачена добыча (${BUILD_LABELS[b.type]})`);
+      b.owner=newOwner;
+      b.hp=BUILD_TYPES[b.type].hpMax;
+    }
   }
 
   // === spawn ===
@@ -793,13 +814,7 @@ window.addEventListener('DOMContentLoaded',()=>{
             animateMove(sel,sel.r,sel.c,tgt.r,tgt.c);
             sel.r=tgt.r; sel.c=tgt.c;
             let bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c&&b.owner!==p);
-            if(bb){
-              const baseTaken = (bb.gen ?? BUILD_TYPES[bb.type].gen)===0;
-              recordEvent(baseTaken
-                ? `Захвачена база`
-                : `Захвачена добыча (${BUILD_LABELS[bb.type]})`);
-              bb.owner=p;
-            }
+            if(bb) damageBuilding(bb,p);
           }
           recordEvent(`${UNIT_LABELS[sel.type]} атаковал ${UNIT_LABELS[tgt.type]} за ${dmg}`+
                       (rdmg?`, получил ${rdmg}`:''));
@@ -814,13 +829,7 @@ window.addEventListener('DOMContentLoaded',()=>{
           sel.mp=zoneMap.rem[y][x];
           let moved = (y!==sel.r || x!==sel.c);
           let bb=buildings.find(b=>b.r===y&&b.c===x&&b.owner!==p);
-          if(bb){
-            const baseTaken = (bb.gen ?? BUILD_TYPES[bb.type].gen)===0;
-            recordEvent(baseTaken
-              ? `Захвачена база`
-              : `Захвачена добыча (${BUILD_LABELS[bb.type]})`);
-            bb.owner=p;
-          }
+          if(bb) damageBuilding(bb,p);
           animateMove(sel,sel.r,sel.c,y,x);
           sel.r=y; sel.c=x;
           if(moved) recordEvent(`Перемещён ${UNIT_LABELS[sel.type]}`);

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -14,7 +14,7 @@ HTMLCanvasElement.prototype.getContext = () => {
   return {
     fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
     stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
-    moveTo:()=>{}, lineTo:()=>{}
+    moveTo:()=>{}, lineTo:()=>{}, createPattern:()=>{}
   };
 };
 
@@ -33,7 +33,7 @@ describe('Fog of Conquest core', () => {
     window.HTMLCanvasElement.prototype.getContext = () => ({
       fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
       stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
-      moveTo:()=>{}, lineTo:()=>{}
+      moveTo:()=>{}, lineTo:()=>{}, createPattern:()=>{}
     });
 
     await new Promise(res => {
@@ -56,6 +56,13 @@ describe('Fog of Conquest core', () => {
     const buildings = window.buildings;
     const bases = buildings.filter(b => b.type === 'base');
     expect(bases.length).toBe(2);
+  });
+
+  test('постройки имеют HP по умолчанию', () => {
+    const { buildings, BUILD_TYPES } = window;
+    buildings.forEach(b => {
+      expect(b.hp).toBe(BUILD_TYPES[b.type].hpMax);
+    });
   });
 
   test('юниты имеют корректные HP и MP после инициализации', () => {
@@ -189,13 +196,13 @@ describe('Fog of Conquest core', () => {
     expect(state.gold[2]).toBe(7);
   });
 
-  test('building is captured when defender dies on it', () => {
+  test('building takes damage and is captured after repeated occupation', () => {
     const { map, TERRAIN, buildings, units, state, BUILD_TYPES, UNIT_TYPES } = window;
     document.getElementById('twoBtn').click();
     units.length = 0;
     buildings.length = 0;
     for(let r=0;r<3;r++)for(let c=0;c<3;c++) map[r][c]=TERRAIN.PLAIN;
-    buildings.push({r:0,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen});
+    buildings.push({r:0,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen,hp:BUILD_TYPES.base.hpMax});
     units.push({id:1,r:0,c:0,owner:2,type:'swordsman',hp:UNIT_TYPES.swordsman.hpMax,mp:UNIT_TYPES.swordsman.move,startR:0,startC:0});
     units.push({id:2,r:0,c:1,owner:1,type:'swordsman',hp:1,mp:UNIT_TYPES.swordsman.move,startR:0,startC:1});
     state.currentPlayer = 2;
@@ -206,6 +213,14 @@ describe('Fog of Conquest core', () => {
     function clickCell(r,c){
       canvas.dispatchEvent(new window.MouseEvent('click',{clientX:(c+0.5)*cellW,clientY:(r+0.5)*cellH}));
     }
+    // kill defender and move onto building (damage)
+    clickCell(0,0);
+    clickCell(0,1);
+    expect(buildings[0].owner).toBe(1);
+    expect(buildings[0].hp).toBe(BUILD_TYPES.base.hpMax-1);
+    window.nextTurn();
+    window.nextTurn();
+    clickCell(0,1); // select unit
     clickCell(0,0);
     clickCell(0,1);
     expect(buildings[0].owner).toBe(2);


### PR DESCRIPTION
## Summary
- give buildings `hpMax` stats
- initialize building HP in `generateMap`
- change capture logic to damage buildings until HP is 0
- show building HP bars in the canvas
- adjust AI capturing logic
- update tests for building HP and new capture flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8d6677b48332a3f32bc418ba0f54