### PR TITLE
Fix beta spawn and add regression tests

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -150,6 +150,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     fort:      {spawn:[],gen:0,def:2,hpMax:2}
   };
 
+  const BASE_SPAWN_DEFAULT = [...BUILD_TYPES.base.spawn];
+
   const UNIT_LABELS = {
     swordsman:'Рубака',
     archer:'Стрелок',
@@ -997,6 +999,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   twoBtn.addEventListener('click',()=>{
     resetState();
     modeBeta=false; revealBtn.style.display='none';
+    BUILD_TYPES.base.spawn = [...BASE_SPAWN_DEFAULT];
     aiMode=false;
     setMapSize(mapSizeSel.value);
     startPanel.style.display='none';
@@ -1012,6 +1015,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   aiStartBtn.addEventListener('click',()=>{
     resetState();
     modeBeta=false; revealBtn.style.display='none';
+    BUILD_TYPES.base.spawn = [...BASE_SPAWN_DEFAULT];
     aiMode=true;
     aiLevel=parseInt(aiLevelSel.value,10);
     window.aiLevel = aiLevel;
@@ -1024,6 +1028,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   betaBtn.addEventListener('click',()=>{
     resetState();
     modeBeta=true; revealBtn.style.display='inline-block';
+    BUILD_TYPES.base.spawn = [...BASE_SPAWN_DEFAULT, 'bog'];
     aiMode=false;
     setMapSize(mapSizeSel.value);
     startPanel.style.display='none';

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -262,4 +262,35 @@ describe('Fog of Conquest core', () => {
     expect(highlight.x).toBeCloseTo(6*cellW);
     expect(highlight.y).toBeCloseTo(5*cellH);
   });
+
+  test('beta mode initialization enables bog spawn and reveal toggling', async () => {
+    const strokes = [];
+    HTMLCanvasElement.prototype.getContext = () => {
+      return {
+        fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
+        stroke:()=>{}, strokeRect:()=>{}, setLineDash:()=>{}, fillText:()=>{},
+        moveTo:()=>{}, lineTo:()=>{}, closePath:()=>{}, createPattern:()=>{}
+      };
+    };
+    const html = fs.readFileSync('index.html','utf8');
+    const dom = new JSDOM(html,{runScripts:'dangerously',resources:'usable',url:`file://${process.cwd()}/index.html`});
+    const win = dom.window;
+    const { document } = win;
+    win.requestAnimationFrame = cb => cb();
+    win.cancelAnimationFrame = () => {};
+    win.HTMLCanvasElement.prototype.getContext = HTMLCanvasElement.prototype.getContext;
+    await new Promise(res=>document.addEventListener('DOMContentLoaded',res));
+    document.getElementById('betaBtn').click();
+
+    expect(win.BUILD_TYPES.base.spawn).toContain('bog');
+    expect(win.units.some(u => u.type === 'bog')).toBe(true);
+    const reveal=document.getElementById('revealBtn');
+    expect(reveal.style.display).not.toBe('none');
+
+    const beforeText=reveal.textContent;
+    reveal.click();
+    const afterText=reveal.textContent;
+    expect(beforeText).toBe('Показать карту');
+    expect(afterText).toBe('Скрыть карту');
+  });
 });


### PR DESCRIPTION
## Summary
- enable bog units for beta mode by altering base spawn list
- keep non-beta modes clean of bogs
- test beta mode initialization and reveal toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9a36c3408332994c3a0781e916da