### PR TITLE
Use sprite overlays for selection

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -493,10 +493,8 @@ window.addEventListener('DOMContentLoaded',()=>{
           Math.abs(u.r-sel.r)+Math.abs(u.c-sel.c)<=UNIT_TYPES[sel.type].range &&
           hasLOS(sel.r,sel.c,u.r,u.c,{forestBlock:false}))
         .forEach(u=>{
-          ctx.strokeStyle='red';
-          ctx.setLineDash([4,4]);
-          ctx.strokeRect(u.c*cellW,u.r*cellH,cellW,cellH);
-          ctx.setLineDash([]);
+          const img=IMG['symbols/red_selection'];
+          if(img) ctx.drawImage(img,u.c*cellW,u.r*cellH,cellW,cellH);
         });
 
       // healable allies for mage
@@ -505,10 +503,8 @@ window.addEventListener('DOMContentLoaded',()=>{
             u.hp<UNIT_TYPES[u.type].hpMax &&
             Math.abs(u.r-sel.r)+Math.abs(u.c-sel.c)<=1)
           .forEach(u=>{
-            ctx.strokeStyle='green';
-            ctx.setLineDash([4,4]);
-            ctx.strokeRect(u.c*cellW,u.r*cellH,cellW,cellH);
-            ctx.setLineDash([]);
+            const img=IMG['symbols/green_selection'];
+            if(img) ctx.drawImage(img,u.c*cellW,u.r*cellH,cellW,cellH);
           });
       }
     }
@@ -601,8 +597,8 @@ window.addEventListener('DOMContentLoaded',()=>{
 
     // selection
     if(sel){
-      ctx.strokeStyle='yellow'; ctx.lineWidth=2; ctx.setLineDash([]);
-      ctx.strokeRect(sel.c*cellW+2,sel.r*cellH+2,cellW-4,cellH-4);
+      const img=IMG['symbols/yellow_selection'];
+      if(img) ctx.drawImage(img,sel.c*cellW,sel.r*cellH,cellW,cellH);
     }
 
     // map border

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -227,14 +227,15 @@ describe('Fog of Conquest core', () => {
   });
 
   test('mage highlights adjacent injured allies', async () => {
-    const strokes = [];
+    const draws = [];
     HTMLCanvasElement.prototype.getContext = () => {
       return {
         strokeStyle:'', lineWidth:0,
         setLineDash:()=>{},
-        strokeRect:function(x,y,w,h){strokes.push({style:this.strokeStyle,x,y,w,h});},
+        strokeRect:()=>{},
+        drawImage:function(img,x,y,w,h){draws.push({img,x,y,w,h});},
         fillRect:()=>{}, clearRect:()=>{}, beginPath:()=>{}, arc:()=>{}, fill:()=>{},
-        stroke:()=>{}, fillText:()=>{}, moveTo:()=>{}, lineTo:()=>{}, closePath:()=>{}, createPattern:()=>{}, drawImage:()=>{}
+        stroke:()=>{}, fillText:()=>{}, moveTo:()=>{}, lineTo:()=>{}, closePath:()=>{}, createPattern:()=>{}
       };
     };
     const html = fs.readFileSync('index.html','utf8');
@@ -252,12 +253,12 @@ describe('Fog of Conquest core', () => {
     units.push({id:1,r:5,c:5,owner:1,type:'mage',hp:UNIT_TYPES.mage.hpMax,mp:UNIT_TYPES.mage.move,startR:5,startC:5});
     units.push({id:2,r:5,c:6,owner:1,type:'swordsman',hp:UNIT_TYPES.swordsman.hpMax-1,mp:UNIT_TYPES.swordsman.move,startR:5,startC:6});
     document.getElementById('revealBtn').click();
-    strokes.length=0;
+    draws.length=0;
     const canvas=document.getElementById('canvas');
     canvas.getBoundingClientRect=()=>({left:0,top:0,width:canvas.width,height:canvas.height});
     const cellW=canvas.width/map[0].length, cellH=canvas.height/map.length;
     canvas.dispatchEvent(new win.MouseEvent('click',{clientX:(5.5)*cellW,clientY:(5.5)*cellH}));
-    const highlight=strokes.find(s=>s.style==='green');
+    const highlight=draws.find(d=>d.img && /green_selection/.test(d.img.src));
     expect(highlight).toBeDefined();
     expect(highlight.x).toBeCloseTo(6*cellW);
     expect(highlight.y).toBeCloseTo(5*cellH);


### PR DESCRIPTION
## Summary
- replace stroked rectangles with highlight sprites for selected units and attack/heal markers
- update unit tests to track drawImage calls instead of strokeRect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685da4b012208332b4d4a99abfd2717c