### PR TITLE
Add basic portrait mode support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -312,6 +312,33 @@ h1 {
   }
 }
 
+@media (orientation: portrait) {
+  #controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  #controls button {
+    margin: 4px 0;
+  }
+  #statsLog {
+    flex-direction: column;
+  }
+  #leftStats {
+    border-right: none;
+    border-bottom: 1px solid #555;
+  }
+  #rightLog {
+    border-bottom: none;
+  }
+  #spawnPanel {
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 80%;
+  }
+}
+
 #legendBtn {
   margin-left: 8px;
   padding: 6px 10px;

--- a/js/core.js
+++ b/js/core.js
@@ -7,6 +7,14 @@ window.addEventListener('DOMContentLoaded',()=>{
 
   const IMG = {};
 
+  const orientationQuery = (typeof window.matchMedia==='function')
+    ? window.matchMedia('(orientation: portrait)')
+    : { matches:false, addEventListener:()=>{}, removeEventListener:()=>{} };
+  function handleOrientation(){
+    window.dispatchEvent(new Event('resize'));
+  }
+  orientationQuery.addEventListener('change', handleOrientation);
+
   function playAudio(a){
     if(!a || isTestEnv) return;
     if(a.dataset.type==='sfx' && !sfxEnabled) return;
@@ -1267,5 +1275,6 @@ window.addEventListener('DOMContentLoaded',()=>{
   loadImages().then(()=>{
     setupLegend();
     window.dispatchEvent(new Event('resize'));
+    handleOrientation();
   });
 });


### PR DESCRIPTION
## Summary
- detect device orientation with `matchMedia`
- trigger canvas resize when orientation changes
- stack controls and stats in portrait view via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db624fda08332ba6fb1acf58171b4