### PR TITLE
Fix fog arrays with map resize

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -348,7 +348,14 @@ window.addEventListener('DOMContentLoaded',()=>{
     requestAnimationFrame(redraw);
   }
 
-  // === Resize & Fog init ===
+  function initFog(){
+    [1,2].forEach(p=>{
+      state.fog[p]  = Array.from({length:ROWS},()=>Array(COLS).fill(true));
+      state.seen[p] = Array.from({length:ROWS},()=>Array(COLS).fill(false));
+    });
+  }
+
+  // === Resize ===
   window.addEventListener('resize',()=>{
     const infoH = document.getElementById('infoPanel').offsetHeight;
     const size = Math.floor(Math.min(
@@ -358,10 +365,6 @@ window.addEventListener('DOMContentLoaded',()=>{
     cellW = cellH = size;
     canvas.width  = cellW * COLS;
     canvas.height = cellH * ROWS;
-    [1,2].forEach(p=>{
-      state.fog[p]  = Array.from({length:ROWS},()=>Array(COLS).fill(true));
-      state.seen[p] = Array.from({length:ROWS},()=>Array(COLS).fill(false));
-    });
     updateAll();
   });
 
@@ -379,10 +382,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     state.gold = {1:5,2:5};
     state.grace = {1:null,2:null};
     state.log   = {1:[],2:[]};
-    [1,2].forEach(p=>{
-      state.fog[p]  = Array.from({length:ROWS},()=>Array(COLS).fill(true));
-      state.seen[p] = Array.from({length:ROWS},()=>Array(COLS).fill(false));
-    });
+    initFog();
     overlay.style.display = 'none';
     spawnPanel.style.display = 'none';
   }
@@ -1179,6 +1179,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     }else{
       ROWS=BASE_ROWS; COLS=BASE_COLS;
     }
+    initFog();
     window.dispatchEvent(new Event('resize'));
   }
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -293,4 +293,18 @@ describe('Fog of Conquest core', () => {
     expect(beforeText).toBe('Показать карту');
     expect(afterText).toBe('Скрыть карту');
   });
+
+  test('starting a new match resets fog after resizing', () => {
+    const { state } = window;
+    state.seen[1][0][0] = true;
+    state.fog[1][0][0] = false;
+    document.getElementById('mapSizeSelect').value = 'large';
+    document.getElementById('twoBtn').click();
+    const rows = window.map.length, cols = window.map[0].length;
+    const r = Math.floor(rows/2), c = Math.floor(cols/2);
+    expect(state.seen[1].length).toBe(rows);
+    expect(state.seen[1][0].length).toBe(cols);
+    expect(state.seen[1][r][c]).toBe(false);
+    expect(state.fog[1][r][c]).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure fog arrays match map size by adding `initFog()`
- call fog initialization whenever the map size changes
- test that fog resets properly when starting a new match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db9183cac8332ae65bc293aab037f