### PR TITLE
Add settings button in start panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <button id="twoBtn">Начать игру</button>
     <button id="aiBtn">Одиночная игра</button>
     <button id="betaBtn">Расширенный режим (бета)</button>
+    <button id="startSettingsBtn">Настройки</button>
   </div>
 
   <div id="aiPanel" style="display:none;">

--- a/js/core.js
+++ b/js/core.js
@@ -85,6 +85,7 @@ window.addEventListener('DOMContentLoaded',()=>{
         waitOverlay = document.getElementById('waitOverlay'),
         waitText    = document.getElementById('waitText'),
         skipReplayBtn = document.getElementById('skipReplayBtn'),
+        startSettingsBtn = document.getElementById('startSettingsBtn'),
         settingsBtn   = document.getElementById('settingsBtn'),
         settingsOverlay = document.getElementById('settingsOverlay'),
         simplifyChk   = document.getElementById('simplifyChk'),
@@ -1136,6 +1137,12 @@ window.addEventListener('DOMContentLoaded',()=>{
     sfxVolumeEl.value = sfxVolume;
     settingsOverlay.style.display='flex';
   });
+
+  if(startSettingsBtn){
+    startSettingsBtn.addEventListener('click', ()=>{
+      settingsBtn.click();
+    });
+  }
   function applySettings(){
     simpleView = simplifyChk.checked;
     musicEnabled = musicEnableEl.checked;


### PR DESCRIPTION
## Summary
- add a "Настройки" button in the start screen
- allow the new button to open the settings overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e45f1a27c833293a5a079dc317e4a