### PR TITLE
Add decorative fonts and unified button styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,8 +12,37 @@ html, body {
 }
 
 h1 {
-  font-family: 'MedievalSharp', cursive;
+  font-family: 'Cinzel Decorative','MedievalSharp', cursive;
   margin-top: 0;
+}
+
+@keyframes pulse {
+  0%,100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+.game-btn {
+  margin: 6px;
+  padding: 10px 20px;
+  background: #bda46a;
+  border: 1px solid #bda46a;
+  border-radius: 4px;
+  color: #2e2e2e;
+  cursor: pointer;
+  font: 1em 'Lora', serif;
+  font-weight: bold;
+  transition: background 0.3s, transform 0.2s;
+}
+
+.game-btn:hover:not(:disabled) {
+  background: #d8c18f;
+  animation: pulse 0.4s ease;
+}
+
+.game-btn:disabled {
+  background: #666;
+  color: #999;
+  cursor: default;
 }
 
 
@@ -27,7 +56,7 @@ h1 {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background: radial-gradient(#222, #000);
+  background: radial-gradient(circle at center, #333, #000);
   color: #eee;
   font: 1.1em 'MedievalSharp', cursive;
   z-index: 30;
@@ -49,26 +78,9 @@ h1 {
 
 #startPanel button {
   margin: 6px;
-  padding: 10px 20px;
-  background: #444;
-  border: none;
-  border-radius: 4px;
-  color: #eee;
-  cursor: pointer;
-  font-family: 'Lora', serif;
-  font-weight: bold;
-  transition: background 0.3s, transform 0.2s;
 }
-
-#startPanel button:disabled {
-  background: #666;
-  color: #999;
-  cursor: default;
-}
-
 #startPanel button:hover:not(:disabled) {
-  background: #666;
-  transform: scale(1.05);
+  animation: pulse 0.4s ease;
 }
 
 #setupOpts {
@@ -257,20 +269,9 @@ h1 {
 
 #controls button {
   margin-left: 8px;
-  padding: 6px 12px;
-  background: #bda46a;
-  border: 1px solid #bda46a;
-  border-radius: 4px;
-  color: #2e2e2e;
-  cursor: pointer;
-  font: 1em 'Lora', serif;
-  font-weight: bold;
-  transition: background 0.3s, transform 0.2s;
 }
-
 #controls button:hover {
-  background: #d8c18f;
-  transform: scale(1.05);
+  animation: pulse 0.4s ease;
 }
 
 #statsLog {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"/>
   <title>Fog of Conquest</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora&family=MedievalSharp&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Lora&family=MedievalSharp&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="css/style.css"/>
 </head>
 <body>
@@ -53,10 +53,10 @@
         <option value="large">Большая</option>
       </select>
     </div>
-    <button id="twoBtn">Начать игру</button>
-    <button id="aiBtn">Одиночная игра</button>
-    <button id="betaBtn">Расширенный режим (бета)</button>
-    <button id="startSettingsBtn">Настройки</button>
+    <button id="twoBtn" class="game-btn">Начать игру</button>
+    <button id="aiBtn" class="game-btn">Одиночная игра</button>
+    <button id="betaBtn" class="game-btn">Расширенный режим (бета)</button>
+    <button id="startSettingsBtn" class="game-btn">Настройки</button>
   </div>
 
   <div id="aiPanel" style="display:none;">
@@ -67,7 +67,7 @@
       <option value="3">Сложная</option>
       <option value="4">Невозможно</option>
     </select>
-    <button id="aiStartBtn">Начать</button>
+    <button id="aiStartBtn" class="game-btn">Начать</button>
   </div>
 
   <div id="overlay">
@@ -112,11 +112,11 @@
 
   <div id="infoPanel">
     <div id="controls">
-      <button id="legendBtn" title="Легенда">ℹ️</button>
-      <button id="settingsBtn">Настройки</button>
-      <button id="revealBtn">Показать карту</button>
-      <button id="tooltipToggle">Подсказки</button>
-      <button id="endTurnBtn">Конец хода</button>
+      <button id="legendBtn" class="game-btn" title="Легенда">ℹ️</button>
+      <button id="settingsBtn" class="game-btn">Настройки</button>
+      <button id="revealBtn" class="game-btn">Показать карту</button>
+      <button id="tooltipToggle" class="game-btn">Подсказки</button>
+      <button id="endTurnBtn" class="game-btn">Конец хода</button>
     </div>
     <div id="statsLog">
       <div id="leftStats"></div>


### PR DESCRIPTION
## Summary
- add Cinzel Decorative font and apply to headings
- add `.game-btn` class for unified button styling and animations
- use `.game-btn` for start menu and in-game control buttons
- lighten start menu background

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4d8539ac8332ba9531272d09845c