### PR TITLE
Add match replay mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -346,7 +346,8 @@ h1 {
 }
 
 #legendOverlay,
-#victoryOverlay {
+#victoryOverlay,
+#replayOverlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -406,11 +407,14 @@ h1 {
 }
 
 #legendOverlay .panel,
-#victoryOverlay .panel {
+#victoryOverlay .panel,
+#replayLog {
   background: #222;
   padding: 20px;
   border: 1px solid #555;
   border-radius: 6px;
+  max-height: 70%;
+  overflow-y: auto;
 }
 
 .legendItem {
@@ -432,7 +436,8 @@ h1 {
 }
 
 #legendOverlay button,
-#victoryOverlay button {
+#victoryOverlay button,
+#replayOverlay button {
   margin-top: 10px;
   padding: 6px 12px;
   background: #bda46a;

--- a/index.html
+++ b/index.html
@@ -84,8 +84,14 @@
   <div id="victoryOverlay">
     <div class="panel">
       <div id="victoryText"></div>
+      <button id="viewReplayBtn">Смотреть повтор</button>
       <button id="victoryOkBtn">Ок</button>
     </div>
+  </div>
+
+  <div id="replayOverlay">
+    <div id="replayLog" class="panel"></div>
+    <button id="exitReplayBtn">В меню</button>
   </div>
 
   <div id="legendOverlay">

--- a/js/core.js
+++ b/js/core.js
@@ -74,7 +74,11 @@ window.addEventListener('DOMContentLoaded',()=>{
         legendCloseBtn = document.getElementById('legendCloseBtn'),
         victoryOverlay = document.getElementById('victoryOverlay'),
         victoryText = document.getElementById('victoryText'),
+        viewReplayBtn = document.getElementById('viewReplayBtn'),
         victoryOkBtn = document.getElementById('victoryOkBtn'),
+        replayOverlay = document.getElementById('replayOverlay'),
+        replayLogDiv  = document.getElementById('replayLog'),
+        exitReplayBtn = document.getElementById('exitReplayBtn'),
         endTurnBtn  = document.getElementById('endTurnBtn'),
         leftStats   = document.getElementById('leftStats'),
         rightLog    = document.getElementById('rightLog'),
@@ -288,6 +292,7 @@ window.addEventListener('DOMContentLoaded',()=>{
       fogSnapshot = null,
       aiReplay = [],
       replayTimer = null,
+      replayEvents = [],
       tooltipEnabled = false;
 
   Object.assign(window, { spawnZones });
@@ -321,11 +326,13 @@ window.addEventListener('DOMContentLoaded',()=>{
     const p = state.currentPlayer;
     state.log[p].push(txt);
     if(aiMode && p===2) state.log[1].push('Враг: '+txt);
+    replayEvents.push(txt);
     renderLog();
   }
   function recordTurn(){
     const p = state.currentPlayer;
     state.log[p].push(`--- Ход ${state.turn+1} ---`);
+    replayEvents.push(`--- Ход ${state.turn+1} ---`);
     renderLog();
   }
   function renderLog(){
@@ -385,6 +392,7 @@ window.addEventListener('DOMContentLoaded',()=>{
     state.gold = {1:5,2:5};
     state.grace = {1:null,2:null};
     state.log   = {1:[],2:[]};
+    replayEvents = [];
     initFog();
     overlay.style.display = 'none';
     spawnPanel.style.display = 'none';
@@ -1174,6 +1182,17 @@ window.addEventListener('DOMContentLoaded',()=>{
     startPanel.style.display='flex';
   });
 
+  viewReplayBtn.addEventListener('click',()=>{
+    victoryOverlay.style.display='none';
+    startMatchReplay();
+  });
+
+  exitReplayBtn.addEventListener('click',()=>{
+    stopMatchReplay();
+    resetState();
+    startPanel.style.display='flex';
+  });
+
   skipReplayBtn.addEventListener('click', stopReplay);
 
   tooltipToggle.addEventListener('click',()=>{
@@ -1296,6 +1315,26 @@ window.addEventListener('DOMContentLoaded',()=>{
       redraw();
     };
     run();
+  }
+
+  function startMatchReplay(){
+    let i=0;
+    replayLogDiv.innerHTML='';
+    replayOverlay.style.display='flex';
+    const run=()=>{
+      if(i>=replayEvents.length){ return; }
+      const line=replayEvents[i++];
+      const d=document.createElement('div');
+      d.textContent=line;
+      replayLogDiv.appendChild(d);
+      replayLogDiv.scrollTop=replayLogDiv.scrollHeight;
+      replayTimer=setTimeout(run,800);
+    };
+    run();
+  }
+  function stopMatchReplay(){
+    if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
+    replayOverlay.style.display='none';
   }
 
   twoBtn.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- track events for replay
- add replay button in victory overlay
- show textual event history sequentially
- allow leaving replay back to the main menu

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e4fe4cf8c8332abfad9546dd2520c