### PR TITLE
Add region-grown terrain and balancing tests

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -447,44 +447,47 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
     const scale = ROWS / BASE_ROWS;
 
-    // --- Terrain generation via layered noise ---
-    const seed = Math.random() * 1000;
-    const noise = (x,y)=>{
-      const n = Math.sin((x*12.9898 + y*78.233 + seed) * 43758.5453);
-      return n - Math.floor(n);
+    // --- Terrain generation via region growing ---
+    const terrainRatios = {
+      [TERRAIN.WATER]: 0.1,
+      [TERRAIN.FOREST]: 0.25,
+      [TERRAIN.HILL]: 0.15,
+      [TERRAIN.MOUNTAIN]: 0.1
     };
-    const layeredNoise = (x,y)=>{
-      let v=0, amp=1, sum=0;
-      for(let i=0;i<3;i++){
-        v += noise(x,y) * amp;
-        sum += amp;
-        x *= 2; y *= 2; amp /= 2;
-      }
-      return v / sum;
+    const totalCells = ROWS * COLS;
+
+    const isBaseArea = (r,c) => {
+      return (r<=2 && c<=2) || (r>=ROWS-3 && c>=COLS-3);
     };
 
-    const waterT = 0.10,
-          forestT = 0.225,
-          hillT = 0.325,
-          mountainT = 0.925;
-
-    for(let r=0;r<ROWS;r++){
-      for(let c=0;c<COLS;c++){
-        let n = layeredNoise(r/ROWS, c/COLS);
-        if(n < waterT) map[r][c] = TERRAIN.WATER;
-        else if(n < forestT) map[r][c] = TERRAIN.FOREST;
-        else if(n < hillT) map[r][c] = TERRAIN.HILL;
-        else {
-          let m = layeredNoise(r/ROWS + 100, c/COLS - 100);
-          if(m > mountainT) map[r][c] = TERRAIN.MOUNTAIN;
+    function blob(type,count,size){
+      const clusters = Math.max(1, Math.round(count / size));
+      for(let i=0;i<clusters && count>0;i++){
+        let r=Math.random()*ROWS|0, c=Math.random()*COLS|0, tries=0;
+        while((map[r][c]!==TERRAIN.PLAIN || isBaseArea(r,c)) && tries<50){
+          r=Math.random()*ROWS|0; c=Math.random()*COLS|0; tries++;
+        }
+        for(let k=0;k<size && count>0;k++){
+          if(map[r][c]===TERRAIN.PLAIN && !isBaseArea(r,c)){
+            map[r][c]=type; count--;
+          }
+          const dir=[[1,0],[-1,0],[0,1],[0,-1]][Math.random()*4|0];
+          r=Math.max(1,Math.min(ROWS-2, r+dir[0]));
+          c=Math.max(1,Math.min(COLS-2, c+dir[1]));
         }
       }
     }
-    // keep mountains away from bases
+
+    Object.entries(terrainRatios).forEach(([t,ratio])=>{
+      const cells=Math.round(totalCells*ratio);
+      blob(parseInt(t,10), cells, 20);
+    });
+
+    // keep bases clear of impassable terrain
     [[1,1],[ROWS-2,COLS-2]].forEach(([br,bc])=>{
       for(let dr=-1;dr<=1;dr++)for(let dc=-1;dc<=1;dc++){
-        let rr=br+dr, cc=bc+dc;
-        if(rr>=0&&rr<ROWS&&cc>=0&&cc<COLS && map[rr][cc]===TERRAIN.MOUNTAIN)
+        const rr=br+dr, cc=bc+dc;
+        if(rr>=0&&rr<ROWS&&cc>=0&&cc<COLS)
           map[rr][cc]=TERRAIN.PLAIN;
       }
     });

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -373,4 +373,39 @@ describe('Fog of Conquest core', () => {
     expect(state.seen[1][r][c]).toBe(false);
     expect(state.fog[1][r][c]).toBe(true);
   });
+
+  test('terrain distribution is balanced and clustered', () => {
+    document.getElementById('twoBtn').click();
+    const { map, TERRAIN } = window;
+    const rows = map.length, cols = map[0].length;
+    const counts = {0:0,1:0,2:0,3:0,4:0};
+    for(let r=0;r<rows;r++)for(let c=0;c<cols;c++) counts[map[r][c]]++;
+    const total = rows*cols;
+    const exp={
+      [TERRAIN.WATER]:0.1,
+      [TERRAIN.FOREST]:0.25,
+      [TERRAIN.HILL]:0.15,
+      [TERRAIN.MOUNTAIN]:0.1
+    };
+    Object.entries(exp).forEach(([t,val])=>{
+      const ratio=counts[t]/total;
+      expect(Math.abs(ratio-val)).toBeLessThan(0.15);
+    });
+
+    const isolated = {1:0,2:0,3:0,4:0};
+    for(let r=0;r<rows;r++)for(let c=0;c<cols;c++){
+      const t=map[r][c];
+      if(t===TERRAIN.PLAIN) continue;
+      const neighbours=[[1,0],[-1,0],[0,1],[0,-1]]
+        .some(([dr,dc])=>{
+          const rr=r+dr, cc=c+dc;
+          return rr>=0&&rr<rows&&cc>=0&&cc<cols && map[rr][cc]===t;
+        });
+      if(!neighbours) isolated[t]++;
+    }
+    [TERRAIN.WATER,TERRAIN.FOREST,TERRAIN.HILL,TERRAIN.MOUNTAIN].forEach(t=>{
+      const ratio=isolated[t]/counts[t];
+      expect(ratio).toBeLessThan(0.4);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- implement region-growing terrain generation instead of layered noise
- ensure bases have clear terrain
- verify new distribution and clustering with jest tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e598e81648332be8c3bf3f7b9735f