### PR TITLE
Implement main menu navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,11 @@ h1 {
 
 #setupOpts {
   margin-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
 }
 
 #setupOpts select {
@@ -386,7 +391,7 @@ h1 {
   border-radius: 6px;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
 }
 
 #settingsOverlay label {
@@ -395,7 +400,7 @@ h1 {
 
 #settingsOverlay button {
   align-self: center;
-  margin-top: 10px;
+  margin: 10px auto 0;
   padding: 6px 12px;
   background: #bda46a;
   border: none;
@@ -415,6 +420,12 @@ h1 {
   border-radius: 6px;
   max-height: 70%;
   overflow-y: auto;
+}
+
+#victoryOverlay .panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .legendItem {

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
       <div id="victoryText"></div>
       <button id="viewReplayBtn" data-i18n="viewReplay">Смотреть повтор</button>
       <button id="victoryOkBtn" data-i18n="victoryOk">Ок</button>
+      <button id="victoryMenuBtn" data-i18n="exitReplay">В меню</button>
     </div>
   </div>
 
@@ -111,6 +112,7 @@
         <option value="en">English</option>
       </select></label>
       <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
+      <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
     </div>
   </div>
 

--- a/js/core.js
+++ b/js/core.js
@@ -76,6 +76,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
         victoryText = document.getElementById('victoryText'),
         viewReplayBtn = document.getElementById('viewReplayBtn'),
         victoryOkBtn = document.getElementById('victoryOkBtn'),
+        victoryMenuBtn = document.getElementById('victoryMenuBtn'),
         replayOverlay = document.getElementById('replayOverlay'),
         replayLogDiv  = document.getElementById('replayLog'),
         exitReplayBtn = document.getElementById('exitReplayBtn'),
@@ -99,6 +100,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
         sfxVolumeEl   = document.getElementById('sfxVolume'),
         langSelect    = document.getElementById('langSelect'),
         settingsCloseBtn = document.getElementById('settingsCloseBtn'),
+        settingsMenuBtn = document.getElementById('settingsMenuBtn'),
         tooltipToggle = document.getElementById('tooltipToggle'),
         tooltipDiv   = document.getElementById('tooltip'),
         bgm          = document.getElementById('bgm'),
@@ -434,6 +436,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
     initFog();
     overlay.style.display = 'none';
     spawnPanel.style.display = 'none';
+  }
+
+  function goToMenu(){
+    resetState();
+    startPanel.style.display='flex';
   }
 
   // === Генерация карты ===
@@ -1227,8 +1234,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
   legendCloseBtn.addEventListener('click',()=>{ legendOverlay.style.display='none'; });
   victoryOkBtn.addEventListener('click',()=>{
     victoryOverlay.style.display='none';
-    resetState();
-    startPanel.style.display='flex';
+    goToMenu();
+  });
+
+  victoryMenuBtn.addEventListener('click',()=>{
+    victoryOverlay.style.display='none';
+    goToMenu();
   });
 
   viewReplayBtn.addEventListener('click',()=>{
@@ -1238,8 +1249,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   exitReplayBtn.addEventListener('click',()=>{
     stopMatchReplay();
-    resetState();
-    startPanel.style.display='flex';
+    goToMenu();
   });
 
   skipReplayBtn.addEventListener('click', stopReplay);
@@ -1286,6 +1296,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   settingsCloseBtn.addEventListener('click',()=>{
     settingsOverlay.style.display='none';
+  });
+
+  settingsMenuBtn.addEventListener('click',()=>{
+    settingsOverlay.style.display='none';
+    goToMenu();
   });
 
   // === UI sounds ===


### PR DESCRIPTION
## Summary
- add 'В меню' button to victory and settings overlays
- centralize going to menu with `goToMenu()`
- wire new buttons in `core.js`
- adjust setup options layout and overlay panel styles for cleaner UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5ab0c274833293fb14828e3c613b