### PR TITLE
Implement game save/load feature

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -384,6 +384,55 @@ h1 {
   text-align: center;
 }
 
+#loadOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font: 1.1em 'Lora', serif;
+  z-index: 50;
+  text-align: center;
+}
+
+#loadOverlay .panel {
+  background: #222;
+  padding: 20px;
+  border: 1px solid #555;
+  border-radius: 6px;
+  max-height: 70%;
+  overflow-y: auto;
+}
+
+#loadOverlay button {
+  margin-top: 10px;
+  padding: 6px 12px;
+  background: #bda46a;
+  border: none;
+  border-radius: 4px;
+  color: #2e2e2e;
+  cursor: pointer;
+  font: 1em 'Lora', serif;
+  font-weight: bold;
+}
+
+.load-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 6px 0;
+}
+
+.load-item button {
+  margin-left: 6px;
+  padding: 4px 8px;
+}
+
 #settingsOverlay .panel {
   background: #222;
   padding: 20px;

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -44,4 +44,9 @@
   "victory": "Player {player} wins!",
   "noAttackWater": "Cannot attack from water",
   "mageHeal": "Mage healed {unit} for 2 HP"
+  ,"saveBtn": "Save"
+  ,"loadBtn": "Load game"
+  ,"loadSave": "Load"
+  ,"deleteSave": "Delete"
+  ,"noSaves": "No saves found"
 }

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -44,4 +44,9 @@
   "victory": "Игрок {player} победил!",
   "noAttackWater": "Нельзя атаковать из воды",
   "mageHeal": "Чародей восстановил {unit} на 2 HP"
+  ,"saveBtn": "Сохранить"
+  ,"loadBtn": "Загрузить игру"
+  ,"loadSave": "Загрузить"
+  ,"deleteSave": "Удалить"
+  ,"noSaves": "Сохранений нет"
 }

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
     <button id="twoBtn" class="game-btn" data-i18n="startTwo">Начать игру</button>
     <button id="aiBtn" class="game-btn" data-i18n="startAi">Одиночная игра</button>
     <button id="betaBtn" class="game-btn" data-i18n="startBeta">Расширенный режим (бета)</button>
+    <button id="loadBtn" class="game-btn" data-i18n="loadBtn">Загрузить игру</button>
     <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">Настройки</button>
   </div>
 
@@ -112,7 +113,14 @@
         <option value="en">English</option>
       </select></label>
       <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
-      <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
+    <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
+    </div>
+  </div>
+
+  <div id="loadOverlay">
+    <div class="panel">
+      <div id="loadList"></div>
+      <button id="loadCloseBtn" data-i18n="settingsClose">Закрыть</button>
     </div>
   </div>
 
@@ -128,6 +136,7 @@
       <button id="settingsBtn" class="game-btn" data-i18n="settingsBtn">Настройки</button>
       <button id="revealBtn" class="game-btn" data-i18n="revealShow">Показать карту</button>
       <button id="tooltipToggle" class="game-btn" data-i18n="tooltip">Подсказки</button>
+      <button id="saveBtn" class="game-btn" data-i18n="saveBtn">Сохранить</button>
       <button id="endTurnBtn" class="game-btn" data-i18n="endTurn">Конец хода</button>
     </div>
     <div id="statsLog">

--- a/js/core.js
+++ b/js/core.js
@@ -108,7 +108,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
         healSfx      = document.getElementById('healSfx'),
         captureSfx   = document.getElementById('captureSfx'),
         uiClickSfx   = document.getElementById('uiClickSfx'),
-        uiHoverSfx   = document.getElementById('uiHoverSfx');
+        uiHoverSfx   = document.getElementById('uiHoverSfx'),
+        loadBtn      = document.getElementById('loadBtn'),
+        loadOverlay  = document.getElementById('loadOverlay'),
+        loadList     = document.getElementById('loadList'),
+        loadCloseBtn = document.getElementById('loadCloseBtn'),
+        saveBtn      = document.getElementById('saveBtn');
 
   // === Константы ===
   const BASE_ROWS = 30, BASE_COLS = 20;
@@ -142,6 +147,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
   };
 
   const SETTINGS_KEY = 'focSettings';
+  const SAVE_PREFIX = 'focSave_';
+  const SAVE_VERSION = 1;
   const isTestEnv = navigator.userAgent.includes('jsdom');
   let simpleView = false,
       musicVolume = 0.5,
@@ -443,6 +450,57 @@ window.addEventListener('DOMContentLoaded', ()=>{
     startPanel.style.display='flex';
   }
 
+  function listSaves(){
+    const arr = [];
+    for(let i=0;i<localStorage.length;i++){
+      const k = localStorage.key(i);
+      if(k && k.startsWith(SAVE_PREFIX)){
+        try{
+          const d = JSON.parse(localStorage.getItem(k));
+          if(d && d.timestamp) arr.push({key:k, timestamp:d.timestamp});
+        }catch(e){}
+      }
+    }
+    return arr.sort((a,b)=>b.timestamp-a.timestamp);
+  }
+
+  function saveGame(){
+    const data = {
+      version: SAVE_VERSION,
+      timestamp: Date.now(),
+      map,
+      buildings,
+      units,
+      state,
+      mapSize,
+      nextUnitId
+    };
+    try{ localStorage.setItem(SAVE_PREFIX+data.timestamp, JSON.stringify(data)); }
+    catch(e){}
+  }
+
+  function loadGameData(key){
+    try{
+      const d = JSON.parse(localStorage.getItem(key));
+      if(!d) return;
+      resetState();
+      map.length = 0; d.map.forEach(row=>map.push([...row]));
+      buildings.length = 0; d.buildings.forEach(b=>buildings.push({...b}));
+      units.length = 0; d.units.forEach(u=>units.push({...u}));
+      Object.assign(state, d.state);
+      mapSize = d.mapSize || mapSize;
+      ROWS = map.length; COLS = map[0].length;
+      nextUnitId = d.nextUnitId || (Math.max(0,...units.map(u=>u.id))+1);
+      startPanel.style.display='none';
+      window.dispatchEvent(new Event('resize'));
+      updateAll();
+    }catch(e){}
+  }
+
+  function deleteSave(key){
+    localStorage.removeItem(key);
+  }
+
   // === Генерация карты ===
   function generateMap(){
     buildings.length = 0;
@@ -576,7 +634,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     nextTurn,
     recordEvent,
     damageBuilding
-  });
+  , saveGame, loadGameData, listSaves, deleteSave });
 
   // === LOS ===
   function hasLOS(r0,c0,r1,c1,{forestBlock=true}={}){
@@ -1308,6 +1366,51 @@ window.addEventListener('DOMContentLoaded', ()=>{
     btn.addEventListener('mouseenter',()=>playAudio(uiHoverSfx));
     btn.addEventListener('click',()=>playAudio(uiClickSfx));
   });
+
+  if(saveBtn){
+    saveBtn.addEventListener('click', saveGame);
+  }
+
+  if(loadBtn){
+    loadBtn.addEventListener('click', ()=>{
+      populateLoadList();
+      loadOverlay.style.display='flex';
+    });
+  }
+
+  function populateLoadList(){
+    loadList.innerHTML = '';
+    const saves = listSaves();
+    if(!saves.length){
+      const div=document.createElement('div');
+      div.textContent = t('noSaves');
+      loadList.appendChild(div);
+      return;
+    }
+    saves.forEach(s=>{
+      const row=document.createElement('div');
+      row.className='load-item';
+      const date=new Date(s.timestamp).toLocaleString();
+      row.innerHTML = `<span>${date}</span>`+
+        `<span><button data-key="${s.key}" class="loadBtn" data-i18n="loadSave">Загрузить</button>`+
+        `<button data-key="${s.key}" class="delBtn" data-i18n="deleteSave">Удалить</button></span>`;
+      loadList.appendChild(row);
+    });
+    applyStrings();
+  }
+
+  loadList.addEventListener('click',e=>{
+    const key=e.target.dataset.key;
+    if(e.target.classList.contains('loadBtn')){
+      loadGameData(key);
+      loadOverlay.style.display='none';
+    }else if(e.target.classList.contains('delBtn')){
+      deleteSave(key);
+      populateLoadList();
+    }
+  });
+
+  loadCloseBtn.addEventListener('click',()=>{loadOverlay.style.display='none';});
 
   // === Туман войны (бета) ===
   revealBtn.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- implement localStorage save/load with version tag
- add Save button and Load overlay
- style load overlay and update translations
- hook load/save buttons in the UI

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e62bb66c083329311087b073c3029