### PR TITLE
Capture only after occupying buildings

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -137,16 +137,10 @@
               u.r=enemy.r; u.c=enemy.c;
               let bb=buildings.find(b=>b.r===u.r&&b.c===u.c&&b.owner!==p);
               if(bb){
-                global.damageBuilding ? global.damageBuilding(bb,p)
-                                      : (bb.owner=p);
-                if(global.damageBuilding){
-                  if(bb.owner===p)
-                    global.addReplay && global.addReplay({type:'capture',building:bb});
-                } else {
-                  global.addReplay && global.addReplay({type:'capture',building:bb});
-                  global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
-                }
+                global.damageBuilding && global.damageBuilding(bb,p);
               }
+              bb=buildings.find(b=>b.r===u.r&&b.c===u.c);
+              if(bb) global.attemptCapture && global.attemptCapture(u, bb);
             }
           }
           u.mp=0;
@@ -251,19 +245,13 @@
           u.mp-=moveCost;
           let bb=buildings.find(b=>b.r===target.r&&b.c===target.c&&b.owner!==p);
           if(bb){
-            global.damageBuilding ? global.damageBuilding(bb,p)
-                                  : (bb.owner=p);
-            if(global.damageBuilding){
-              if(bb.owner===p)
-                global.addReplay && global.addReplay({type:'capture',building:bb});
-            } else {
-              global.addReplay && global.addReplay({type:'capture',building:bb});
-              global.recordEvent && global.recordEvent(`Захвачено ${global.BUILD_LABELS[bb.type]}`);
-            }
+            global.damageBuilding && global.damageBuilding(bb,p);
           }
           global.addReplay && global.addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:target.r,c:target.c}});
           global.recordEvent && global.recordEvent(`${global.UNIT_LABELS[u.type]} переместился`);
           u.r=target.r; u.c=target.c;
+          bb = buildings.find(b=>b.r===u.r && b.c===u.c);
+          if(bb) global.attemptCapture && global.attemptCapture(u, bb);
         } else break;
       }
     });

--- a/js/core.js
+++ b/js/core.js
@@ -724,6 +724,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     nextTurn,
     recordEvent,
     damageBuilding,
+    attemptCapture,
     resetState
   , saveGame, loadGameData, listSaves, deleteSave });
 
@@ -1071,16 +1072,21 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   function damageBuilding(b, newOwner, dmg=1){
     if(!b) return;
-    b.hp-=dmg;
-    if(b.hp<=0){
-      const baseTaken=(b.gen ?? BUILD_TYPES[b.type].gen)===0;
+    b.hp -= dmg;
+    if(b.hp <= 0) b.hp = 0;
+  }
+
+  function attemptCapture(unit, building){
+    if(!building) return;
+    if(unit.r===building.r && unit.c===building.c && building.hp<=0){
+      const baseTaken = (building.gen ?? BUILD_TYPES[building.type].gen) === 0;
       recordEvent(baseTaken
         ? `Захвачена база`
-        : `Захвачена добыча (${BUILD_LABELS[b.type]})`);
+        : `Захвачена добыча (${BUILD_LABELS[building.type]})`);
       playAudio(captureSfx);
-      b.owner=newOwner;
-      b.hp=BUILD_TYPES[b.type].hpMax;
-      if(!aiMode) addReplay({type:'capture',building:b});
+      building.owner = unit.owner;
+      building.hp = BUILD_TYPES[building.type].hpMax;
+      if(!aiMode) addReplay({type:'capture', building});
     }
   }
 
@@ -1232,6 +1238,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
             sel.r=tgt.r; sel.c=tgt.c;
             let bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c&&b.owner!==p);
             if(bb) damageBuilding(bb,p);
+            bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c);
+            if(bb) attemptCapture(sel, bb);
           }
           recordEvent(`${UNIT_LABELS[sel.type]} атаковал ${UNIT_LABELS[tgt.type]} за ${dmg}`+
                       (rdmg?`, получил ${rdmg}`:''));
@@ -1269,6 +1277,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
           if(moved && !aiMode) addReplay({type:'move',unit:sel,from,to:{r:y,c:x}});
           animateMove(sel,sel.r,sel.c,y,x);
           sel.r=y; sel.c=x;
+          bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c);
+          if(bb) attemptCapture(sel, bb);
           if(moved) recordEvent(`Перемещён ${UNIT_LABELS[sel.type]}`);
           if(sel.mp>0){
             let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -221,6 +221,9 @@ describe('Fog of Conquest core', () => {
     for(let i=1;i<BUILD_TYPES.base.hpMax;i++){
       window.damageBuilding(buildings[0],2);
     }
+    expect(buildings[0].owner).toBe(1);
+    expect(buildings[0].hp).toBe(0);
+    window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);
     expect(buildings[0].hp).toBe(BUILD_TYPES.base.hpMax);
   });
@@ -241,6 +244,12 @@ describe('Fog of Conquest core', () => {
     expect(base.hp).toBe(BUILD_TYPES.base.hpMax - 2);
     expect(base.owner).toBe(1);
     doAttackBuilding(archer, base);
+    expect(base.owner).toBe(1);
+    expect(base.hp).toBe(0);
+    // move archer onto the building and capture
+    archer.r = base.r;
+    archer.c = base.c;
+    window.attemptCapture(archer, base);
     expect(base.owner).toBe(2);
     expect(base.hp).toBe(BUILD_TYPES.base.hpMax);
   });
@@ -335,6 +344,9 @@ describe('Fog of Conquest core', () => {
     expect(buildings[0].owner).toBe(1);
     expect(buildings[0].hp).toBe(BUILD_TYPES.base.hpMax - 1);
     for(let i=1;i<BUILD_TYPES.base.hpMax;i++) window.damageBuilding(buildings[0],2);
+    expect(buildings[0].owner).toBe(1);
+    expect(buildings[0].hp).toBe(0);
+    window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);
     expect(buildings[0].hp).toBe(BUILD_TYPES.base.hpMax);
   });


### PR DESCRIPTION
## Summary
- tweak `damageBuilding` so buildings stay at 0 HP
- add `attemptCapture` and call it when units end movement on buildings
- update AI logic to use the new capture mechanic
- adjust tests for the changed capture flow

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e764fa6c483328d63007e2597f57e