### PR TITLE
Move save and hints settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,10 @@
         <option value="en">English</option>
         <option value="uk">Українська</option>
       </select></label>
+      <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
+      <button id="saveBtn" data-i18n="saveBtn">Сохранить</button>
       <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
-    <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
+      <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
     </div>
   </div>
 
@@ -140,8 +142,6 @@
       <button id="legendBtn" class="game-btn" title="Легенда" data-i18n-title="legendBtnTitle">ℹ️</button>
       <button id="settingsBtn" class="game-btn" data-i18n="settingsBtn">Настройки</button>
       <button id="revealBtn" class="game-btn" data-i18n="revealShow">Показать карту</button>
-      <button id="tooltipToggle" class="game-btn" data-i18n="tooltip">Подсказки</button>
-      <button id="saveBtn" class="game-btn" data-i18n="saveBtn">Сохранить</button>
       <button id="endTurnBtn" class="game-btn" data-i18n="endTurn">Конец хода</button>
     </div>
     <div id="statsLog">

--- a/js/core.js
+++ b/js/core.js
@@ -110,7 +110,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
         langSelect    = document.getElementById('langSelect'),
         settingsCloseBtn = document.getElementById('settingsCloseBtn'),
         settingsMenuBtn = document.getElementById('settingsMenuBtn'),
-        tooltipToggle = document.getElementById('tooltipToggle'),
+        hintsChk = document.getElementById('hintsChk'),
         tooltipDiv   = document.getElementById('tooltip'),
         bgm          = document.getElementById('bgm'),
         attackSfx    = document.getElementById('attackSfx'),
@@ -1420,9 +1420,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   skipReplayBtn.addEventListener('click', stopReplay);
 
-  tooltipToggle.addEventListener('click',()=>{
-    tooltipEnabled = !tooltipEnabled;
-    tooltipToggle.textContent = tooltipEnabled ? t('tooltipOn') : t('tooltip');
+  hintsChk.addEventListener('change',()=>{
+    tooltipEnabled = hintsChk.checked;
     if(!tooltipEnabled) tooltipDiv.style.display = 'none';
   });
 
@@ -1433,6 +1432,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     sfxEnableEl.checked = sfxEnabled;
     sfxVolumeEl.value = sfxVolume;
     langSelect.value = lang;
+    hintsChk.checked = tooltipEnabled;
     settingsOverlay.style.display='flex';
   });
 


### PR DESCRIPTION
## Summary
- move save and tooltip controls from the game panel into the settings overlay
- hook up new `hintsChk` checkbox in JS
- keep save button functionality in its new location

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e7a3af08c833298a767d01742c0e8