### PR TITLE
Improve start menu layout and settings overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,7 +77,13 @@ h1 {
 }
 
 #startPanel button {
-  margin: 6px;
+  margin: 0;
+}
+#startButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
 }
 #startPanel button:hover:not(:disabled) {
   animation: pulse 0.4s ease;
@@ -380,7 +386,7 @@ h1 {
   background: rgba(0, 0, 0, 0.8);
   color: #fff;
   font: 1.1em 'Lora', serif;
-  z-index: 50;
+  z-index: 60;
   text-align: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -53,11 +53,13 @@
         <option value="large" data-i18n="mapSizeLarge">Большая</option>
       </select>
     </div>
-    <button id="twoBtn" class="game-btn" data-i18n="startTwo">Начать игру</button>
-    <button id="aiBtn" class="game-btn" data-i18n="startAi">Одиночная игра</button>
-    <button id="betaBtn" class="game-btn" data-i18n="startBeta">Расширенный режим (бета)</button>
-    <button id="loadBtn" class="game-btn" data-i18n="loadBtn">Загрузить игру</button>
-    <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">Настройки</button>
+    <div id="startButtons">
+      <button id="twoBtn" class="game-btn" data-i18n="startTwo">Начать игру</button>
+      <button id="aiBtn" class="game-btn" data-i18n="startAi">Одиночная игра</button>
+      <button id="betaBtn" class="game-btn" data-i18n="startBeta">Расширенный режим (бета)</button>
+      <button id="loadBtn" class="game-btn" data-i18n="loadBtn">Загрузить игру</button>
+      <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">Настройки</button>
+    </div>
   </div>
 
   <div id="aiPanel" style="display:none;">


### PR DESCRIPTION
## Summary
- align start menu buttons in a flex column for consistent spacing
- wrap start menu buttons in new `#startButtons` container
- raise `#settingsOverlay` z-index to ensure it shows above menus

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e7bdfc9f88332aefa573a57ff8e31