### PR TITLE
Implement UI and gameplay improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,14 @@ h1 {
   gap: 8px;
   align-items: center;
 }
+
+#newGameOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  margin-top: 10px;
+}
 #startPanel button:hover:not(:disabled) {
   animation: pulse 0.4s ease;
 }
@@ -219,6 +227,7 @@ h1 {
   box-shadow: 0 0 8px rgba(0,0,0,0.4);
   border: 1px solid #777;
   image-rendering: auto;
+  touch-action: manipulation;
 }
 
 #spawnPanel {
@@ -374,6 +383,15 @@ h1 {
   text-align: center;
 }
 
+#replayOverlay {
+  background: none;
+  pointer-events: none;
+}
+
+#replayOverlay > * {
+  pointer-events: auto;
+}
+
 #settingsOverlay {
   position: fixed;
   top: 0;
@@ -475,6 +493,15 @@ h1 {
   border-radius: 6px;
   max-height: 70%;
   overflow-y: auto;
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+#exitReplayBtn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
 }
 
 #victoryOverlay .panel {
@@ -515,15 +542,6 @@ h1 {
   font-weight: bold;
 }
 
-#replayControls {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 10px;
-}
-
-#replayControls .speedBtn {
-  padding: 4px 8px;
-}
 
 /* Styling for shield icons drawn on canvas */
 .shield-icon {

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -49,4 +49,7 @@
   ,"loadSave": "Load"
   ,"deleteSave": "Delete"
   ,"noSaves": "No saves found"
+  ,"newGame": "Start new game"
+  ,"fullscreen": "Fullscreen"
+  ,"replaySide": "Switch side"
 }

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -49,4 +49,7 @@
   ,"loadSave": "Загрузить"
   ,"deleteSave": "Удалить"
   ,"noSaves": "Сохранений нет"
+  ,"newGame": "Новая игра"
+  ,"fullscreen": "Полный экран"
+  ,"replaySide": "Сменить сторону"
 }

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -49,4 +49,7 @@
   "loadSave": "Завантажити",
   "deleteSave": "Видалити",
   "noSaves": "Немає збережень"
+  ,"newGame": "Нова гра"
+  ,"fullscreen": "Повний екран"
+  ,"replaySide": "Змінити сторону"
 }

--- a/index.html
+++ b/index.html
@@ -44,21 +44,24 @@
       • Правой кнопкой отменяйте выбор.<br>
       • Кнопка «ℹ️» показывает легенду, а «Показать карту» доступна в бета-режиме.
       </div>
-    <div id="setupOpts">
-      <label for="mapSizeSelect" data-i18n="mapSizeLabel">Размер карты:</label>
-      <select id="mapSizeSelect">
-        <option value="tiny" data-i18n="mapSizeTiny">Крошечная</option>
-        <option value="small" data-i18n="mapSizeSmall">Маленькая</option>
-        <option value="medium" selected data-i18n="mapSizeMedium">Средняя</option>
-        <option value="large" data-i18n="mapSizeLarge">Большая</option>
-      </select>
-    </div>
     <div id="startButtons">
-      <button id="twoBtn" class="game-btn" data-i18n="startTwo">Начать игру</button>
-      <button id="aiBtn" class="game-btn" data-i18n="startAi">Одиночная игра</button>
-      <button id="betaBtn" class="game-btn" data-i18n="startBeta">Расширенный режим (бета)</button>
+      <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">⚙</button>
       <button id="loadBtn" class="game-btn" data-i18n="loadBtn">Загрузить игру</button>
-      <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">Настройки</button>
+      <button id="newGameBtn" class="game-btn" data-i18n="newGame">Начать новую игру</button>
+      <div id="newGameOptions" style="display:none; flex-direction:column; align-items:center;">
+        <div id="setupOpts">
+          <label for="mapSizeSelect" data-i18n="mapSizeLabel">Размер карты:</label>
+          <select id="mapSizeSelect">
+            <option value="tiny" data-i18n="mapSizeTiny">Крошечная</option>
+            <option value="small" data-i18n="mapSizeSmall">Маленькая</option>
+            <option value="medium" selected data-i18n="mapSizeMedium">Средняя</option>
+            <option value="large" data-i18n="mapSizeLarge">Большая</option>
+          </select>
+        </div>
+        <button id="twoBtn" class="game-btn" data-i18n="startTwo">Два игрока</button>
+        <button id="aiBtn" class="game-btn" data-i18n="startAi">Один игрок</button>
+        <button id="betaBtn" class="game-btn" data-i18n="startBeta">Бета-игра</button>
+      </div>
     </div>
   </div>
 
@@ -98,6 +101,7 @@
       <button class="speedBtn" data-speed="0.5">0.5×</button>
       <button class="speedBtn" data-speed="1">1×</button>
       <button class="speedBtn" data-speed="2">2×</button>
+      <button id="replaySideBtn" data-i18n="replaySide">Сменить сторону</button>
     </div>
     <button id="exitReplayBtn" data-i18n="exitReplay">В меню</button>
   </div>
@@ -120,6 +124,7 @@
         <option value="uk">Українська</option>
       </select></label>
       <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
+      <button id="fullscreenBtn" data-i18n="fullscreen">Fullscreen</button>
       <button id="saveBtn" data-i18n="saveBtn">Сохранить</button>
       <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
       <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
@@ -142,7 +147,7 @@
   <div id="infoPanel">
     <div id="controls">
       <button id="legendBtn" class="game-btn" title="Легенда" data-i18n-title="legendBtnTitle">ℹ️</button>
-      <button id="settingsBtn" class="game-btn" data-i18n="settingsBtn">Настройки</button>
+      <button id="settingsBtn" class="game-btn" data-i18n="settingsBtn">⚙</button>
       <button id="revealBtn" class="game-btn" data-i18n="revealShow">Показать карту</button>
       <button id="endTurnBtn" class="game-btn" data-i18n="endTurn">Конец хода</button>
     </div>

--- a/js/core.js
+++ b/js/core.js
@@ -122,10 +122,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
         loadOverlay  = document.getElementById('loadOverlay'),
         loadList     = document.getElementById('loadList'),
         loadCloseBtn = document.getElementById('loadCloseBtn'),
-        saveBtn      = document.getElementById('saveBtn');
+        saveBtn      = document.getElementById('saveBtn'),
+        fullscreenBtn = document.getElementById('fullscreenBtn'),
+        newGameBtn   = document.getElementById('newGameBtn'),
+        newGameOptions = document.getElementById('newGameOptions'),
+        replaySideBtn = document.getElementById('replaySideBtn');
 
   // === Константы ===
-  const BASE_ROWS = 30, BASE_COLS = 20;
+  // default orientation switched to horizontal
+  const BASE_ROWS = 20, BASE_COLS = 30;
   let ROWS = BASE_ROWS, COLS = BASE_COLS;
   let mapSize = 'medium';
   let aiMode = false, aiLevel = 2;
@@ -350,6 +355,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
       replayTimer = null,
       replayEvents = [],
       replaySpeed = 1,
+      replaySide = null,
+      currentReplaySnapshot = null,
       tooltipEnabled = false;
 
   Object.assign(window, { spawnZones });
@@ -477,6 +484,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
   function goToMenu(){
     resetState();
     startPanel.style.display='flex';
+    if(newGameOptions) newGameOptions.style.display='none';
+    if(newGameBtn) newGameBtn.style.display='inline-block';
   }
 
   function listSaves(){
@@ -1255,6 +1264,18 @@ window.addEventListener('DOMContentLoaded', ()=>{
             recordEvent(t('noAttackWater'));
             sel=null; zoneMap=null; zoneList=[]; updateAll(); return;
           }
+          if(bldTgt.hp<=0){
+            const from={r:sel.r,c:sel.c};
+            sel.mp=zoneMap.rem[bldTgt.r][bldTgt.c]>=0?zoneMap.rem[bldTgt.r][bldTgt.c]:0;
+            if(!aiMode) addReplay({type:'move',unit:sel,from,to:{r:bldTgt.r,c:bldTgt.c}});
+            animateMove(sel,sel.r,sel.c,bldTgt.r,bldTgt.c);
+            sel.r=bldTgt.r; sel.c=bldTgt.c;
+            attemptCapture(sel,bldTgt);
+            recordEvent(`Перемещён ${UNIT_LABELS[sel.type]}`);
+            if(sel.mp>0){ let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list; }
+            else { sel=null; zoneMap=null; zoneList=[]; }
+            updateAll(); return;
+          }
           sel.mp=0;
           const {dmg}=doAttackBuilding(sel,bldTgt);
           if(!aiMode) addReplay({type:'attack',target:bldTgt});
@@ -1417,6 +1438,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
       replaySpeed=parseFloat(btn.dataset.speed);
     });
   });
+  if(replaySideBtn){
+    replaySideBtn.addEventListener('click',()=>{
+      replaySide = replaySide===1?2:1;
+      applySnapshot(currentReplaySnapshot);
+    });
+  }
 
   skipReplayBtn.addEventListener('click', stopReplay);
 
@@ -1439,6 +1466,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
   if(startSettingsBtn){
     startSettingsBtn.addEventListener('click', ()=>{
       settingsBtn.click();
+    });
+  }
+  if(newGameBtn){
+    newGameBtn.addEventListener('click', ()=>{
+      newGameBtn.style.display='none';
+      if(newGameOptions) newGameOptions.style.display='flex';
     });
   }
   async function applySettings(){
@@ -1468,6 +1501,16 @@ window.addEventListener('DOMContentLoaded', ()=>{
     settingsOverlay.style.display='none';
     goToMenu();
   });
+
+  if(fullscreenBtn){
+    fullscreenBtn.addEventListener('click',()=>{
+      if(!document.fullscreenElement){
+        document.documentElement.requestFullscreen().catch(()=>{});
+      }else{
+        document.exitFullscreen().catch(()=>{});
+      }
+    });
+  }
 
   // === UI sounds ===
   document.querySelectorAll('button').forEach(btn=>{
@@ -1600,7 +1643,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     if(!snap) return;
     units.length=0; snap.units.forEach(u=>units.push({...u}));
     buildings.length=0; snap.buildings.forEach(b=>buildings.push({...b}));
-    state.currentPlayer=snap.state.currentPlayer;
+    state.currentPlayer = replaySide || snap.state.currentPlayer;
     state.turn=snap.state.turn;
     state.gold={...snap.state.gold};
     updateAll();
@@ -1623,20 +1666,24 @@ window.addEventListener('DOMContentLoaded', ()=>{
     let i=1;
     replaySpeed = 1;
     revealAll = true;
-    applySnapshot(replayEvents[0].snapshot);
+    replaySide = 1;
+    currentReplaySnapshot = replayEvents[0].snapshot;
+    applySnapshot(currentReplaySnapshot);
     replayOverlay.style.display='flex';
     const run=()=>{
       if(i>=replayEvents.length){ return; }
       const ev=replayEvents[i++];
       handleReplayAction(ev.action);
       const base=ev.action? (ev.action.type==='move'?300:ev.action.type==='attack'?150:250) : 400;
-      replayTimer=setTimeout(()=>{ applySnapshot(ev.snapshot); run(); }, base/replaySpeed);
+      replayTimer=setTimeout(()=>{ currentReplaySnapshot=ev.snapshot; applySnapshot(ev.snapshot); run(); }, base/replaySpeed);
     };
     run();
   }
   function stopMatchReplay(){
     if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
     replayOverlay.style.display='none';
+    replaySide = null;
+    revealAll = false;
   }
 
   twoBtn.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- adjust default map orientation to be horizontal
- restructure start menu with a new-game sub menu
- replace settings buttons with gear icon and add fullscreen option
- enhance replay UX: no dimming, side toggle, controls repositioned
- allow units to capture zero-HP buildings by moving onto them
- prevent mobile double-tap zoom

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e829c7e6c83329c218a0d4f76ae98