### PR TITLE
Improve mobile UI layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,7 @@ html, body {
   width: 100%;
   height: 100%;
   overflow: hidden;
+  touch-action: manipulation;
   background: radial-gradient(#111, #000);
   color: #2e2e2e;
   font-family: 'MedievalSharp', cursive;
@@ -31,6 +32,9 @@ h1 {
   cursor: pointer;
   font: 1em 'Lora', serif;
   font-weight: bold;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
   transition: background 0.3s, transform 0.2s;
 }
 
@@ -61,6 +65,26 @@ h1 {
   font: 1.1em 'MedievalSharp', cursive;
   z-index: 30;
   text-shadow: 0 0 6px #000;
+}
+
+#startHeader {
+  width: 80%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+#startHeader h1 {
+  margin: 0 auto;
+}
+
+#startHeader button {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 #summary {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+  <meta name="theme-color" content="#000000"/>
   <title>Fog of Conquest</title>
   <link href="https://fonts.googleapis.com/css2?family=Lora&family=MedievalSharp&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="css/style.css"/>
@@ -15,7 +19,10 @@
   <audio id="uiClickSfx" src="https://samplelib.com/lib/preview/mp3/sample-12s.mp3" data-type="sfx"></audio>
   <audio id="uiHoverSfx" src="https://samplelib.com/lib/preview/mp3/sample-15s.mp3" data-type="sfx"></audio>
   <div id="startPanel">
-    <h1 data-i18n="title">Fog of Conquest</h1>
+    <div id="startHeader">
+      <h1 data-i18n="title">Fog of Conquest</h1>
+      <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">⚙</button>
+    </div>
     <div id="summary" data-i18n="summary">
       <strong>Суть игры:</strong><br>
       Fog of Conquest — пошаговая стратегия. Главная цель – захватить или разрушить все базы противника и тем самым лишить его возможности нанимать войска.<br><br>
@@ -45,7 +52,6 @@
       • Кнопка «ℹ️» показывает легенду, а «Показать карту» доступна в бета-режиме.
       </div>
     <div id="startButtons">
-      <button id="startSettingsBtn" class="game-btn" data-i18n="startSettings">⚙</button>
       <button id="loadBtn" class="game-btn" data-i18n="loadBtn">Загрузить игру</button>
       <button id="newGameBtn" class="game-btn" data-i18n="newGame">Начать новую игру</button>
       <div id="newGameOptions" style="display:none; flex-direction:column; align-items:center;">

--- a/js/core.js
+++ b/js/core.js
@@ -448,7 +448,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   // === Resize ===
   window.addEventListener('resize',()=>{
-    const infoH = document.getElementById('infoPanel').offsetHeight;
+    const infoPanel = document.getElementById('infoPanel');
+    const infoH = infoPanel.offsetHeight;
     const size = Math.floor(Math.min(
       window.innerWidth / COLS,
       (window.innerHeight - infoH) / ROWS
@@ -456,6 +457,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
     cellW = cellH = size;
     canvas.width  = cellW * COLS;
     canvas.height = cellH * ROWS;
+    const extra = window.innerHeight - infoH - canvas.height;
+    infoPanel.style.bottom = extra > 0 ? extra + 'px' : '0';
     updateAll();
   });
 


### PR DESCRIPTION
## Summary
- allow body content to use touch-action: manipulation
- prevent text selection and double-tap zoom on game buttons
- add header container with settings button and style it
- reposition info panel dynamically so map occupies full top height
- add mobile full-screen meta tags

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9af2bde48332ada9ff58cc7dddc4