### PR TITLE
Fix info panel positioning on resize

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -457,8 +457,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     cellW = cellH = size;
     canvas.width  = cellW * COLS;
     canvas.height = cellH * ROWS;
-    const extra = window.innerHeight - infoH - canvas.height;
-    infoPanel.style.bottom = extra > 0 ? extra + 'px' : '0';
+    infoPanel.style.bottom = '0';
     updateAll();
   });
 


### PR DESCRIPTION
## Summary
- ensure `infoPanel` remains anchored at the page bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea55efd008332ab87c32bf9518c61