### PR TITLE
Fix fullscreen button for Safari

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1505,11 +1505,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
   });
 
   if(fullscreenBtn){
-    fullscreenBtn.addEventListener('click',()=>{
-      if(!document.fullscreenElement){
-        document.documentElement.requestFullscreen().catch(()=>{});
-      }else{
-        document.exitFullscreen().catch(()=>{});
+    fullscreenBtn.addEventListener('click', () => {
+      if (!document.fullscreenElement && !document.webkitFullscreenElement) {
+        const el = document.documentElement;
+        (el.requestFullscreen || el.webkitRequestFullscreen)?.call(el);
+      } else {
+        (document.exitFullscreen || document.webkitExitFullscreen)?.call(document);
       }
     });
   }


### PR DESCRIPTION
## Summary
- use webkit API as fallback for fullscreen button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ea684a4288332917972020f3209b1