### PR TITLE
Adjust settings panel width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -491,15 +491,21 @@ h1 {
   padding: 20px;
   border: 1px solid #555;
   border-radius: 6px;
-  width: 90%;
-  max-width: 400px;
+  width: auto;
+  max-width: 600px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
 }
 
 #settingsOverlay label {
   margin: 6px 0;
+}
+
+#settingsOverlay input[type="range"],
+#settingsOverlay select {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 #settingsOverlay button {


### PR DESCRIPTION
## Summary
- allow `.panel` inside settings overlay to size itself and widen up to 600px
- ensure range inputs and select boxes expand to full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb38422ec8332be74ec36142bf0bb