### PR TITLE
Show save button only during game

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
       </select></label>
       <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
       <button id="fullscreenBtn" data-i18n="fullscreen">Fullscreen</button>
-      <button id="saveBtn" data-i18n="saveBtn">Сохранить</button>
+      <button id="saveBtn" style="display:none;" data-i18n="saveBtn">Сохранить</button>
       <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
       <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
     </div>

--- a/js/core.js
+++ b/js/core.js
@@ -1462,6 +1462,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
     sfxVolumeEl.value = sfxVolume;
     langSelect.value = lang;
     hintsChk.checked = tooltipEnabled;
+    if(saveBtn){
+      saveBtn.style.display = (startPanel.style.display === 'none') ? 'block' : 'none';
+    }
     settingsOverlay.style.display='flex';
   });
 


### PR DESCRIPTION
## Summary
- hide `saveBtn` by default in settings dialog
- toggle save button visibility when opening settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb61e24fc8332b1992db6ecb1f013