### PR TITLE
Style settings close button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -526,6 +526,16 @@ h1 {
   font-weight: bold;
 }
 
+#settingsCloseBtn {
+  background: #d9534f;
+  color: #fff;
+  margin-top: 20px;
+}
+
+#settingsCloseBtn:hover {
+  background: #c9302c;
+}
+
 #legendOverlay .panel,
 #victoryOverlay .panel,
 #replayControls {

--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
       <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
       <button id="fullscreenBtn" data-i18n="fullscreen">Fullscreen</button>
       <button id="saveBtn" style="display:none;" data-i18n="saveBtn">Сохранить</button>
-      <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
       <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
+      <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- reposition the Settings overlay close button
- add red styling for the close button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb767824883329645f7befbba2a9b