### PR TITLE
Fix settings layout and unify button animations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -496,15 +496,18 @@ h1 {
   padding: 20px;
   border: 1px solid #555;
   border-radius: 6px;
-  width: auto;
-  max-width: 600px;
+  width: 80%;
+  max-width: 800px;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
 }
 
 #settingsOverlay label {
   margin: 6px 0;
+  flex: 1 1 45%;
+  text-align: left;
 }
 
 #settingsOverlay input[type="range"],
@@ -514,8 +517,8 @@ h1 {
 }
 
 #settingsOverlay button {
-  align-self: center;
-  margin: 10px auto 0;
+  flex: 1 1 45%;
+  margin: 10px;
   padding: 6px 12px;
   background: #bda46a;
   border: none;
@@ -527,13 +530,13 @@ h1 {
 }
 
 #settingsCloseBtn {
-  background: #d9534f;
-  color: #fff;
+  background: #c4a05d;
+  color: #2e2e2e;
   margin-top: 20px;
 }
 
 #settingsCloseBtn:hover {
-  background: #c9302c;
+  background: #d0ad69;
 }
 
 #legendOverlay .panel,

--- a/index.html
+++ b/index.html
@@ -87,37 +87,37 @@
 
   <div id="overlay">
     <div id="overlayMessage"></div>
-    <button id="yesBtn" data-i18n="yes">Ок</button>
-    <button id="noBtn" data-i18n="no">Отмена</button>
+    <button id="yesBtn" class="game-btn" data-i18n="yes">Ок</button>
+    <button id="noBtn" class="game-btn" data-i18n="no">Отмена</button>
   </div>
 
   <div id="waitOverlay">
     <div id="waitText" data-i18n="wait">Подождите...</div>
-    <button id="skipReplayBtn" style="display:none;" data-i18n="skip">Пропустить</button>
+    <button id="skipReplayBtn" class="game-btn" style="display:none;" data-i18n="skip">Пропустить</button>
   </div>
 
   <div id="victoryOverlay">
     <div class="panel">
       <div id="victoryText"></div>
-      <button id="viewReplayBtn" data-i18n="viewReplay">Смотреть повтор</button>
-      <button id="victoryOkBtn" data-i18n="victoryOk">Ок</button>
-      <button id="victoryMenuBtn" data-i18n="exitReplay">В меню</button>
+      <button id="viewReplayBtn" class="game-btn" data-i18n="viewReplay">Смотреть повтор</button>
+      <button id="victoryOkBtn" class="game-btn" data-i18n="victoryOk">Ок</button>
+      <button id="victoryMenuBtn" class="game-btn" data-i18n="exitReplay">В меню</button>
     </div>
   </div>
 
   <div id="replayOverlay">
     <div id="replayControls">
-      <button class="speedBtn" data-speed="0.5">0.5×</button>
-      <button class="speedBtn" data-speed="1">1×</button>
-      <button class="speedBtn" data-speed="2">2×</button>
-      <button id="replaySideBtn" data-i18n="replaySide">Сменить сторону</button>
+      <button class="speedBtn game-btn" data-speed="0.5">0.5×</button>
+      <button class="speedBtn game-btn" data-speed="1">1×</button>
+      <button class="speedBtn game-btn" data-speed="2">2×</button>
+      <button id="replaySideBtn" class="game-btn" data-i18n="replaySide">Сменить сторону</button>
     </div>
-    <button id="exitReplayBtn" data-i18n="exitReplay">В меню</button>
+    <button id="exitReplayBtn" class="game-btn" data-i18n="exitReplay">В меню</button>
   </div>
 
   <div id="legendOverlay">
     <div class="panel" id="legendPanel"></div>
-    <button id="legendCloseBtn" data-i18n="legendClose">Закрыть</button>
+    <button id="legendCloseBtn" class="game-btn" data-i18n="legendClose">Закрыть</button>
   </div>
 
   <div id="settingsOverlay">
@@ -133,17 +133,17 @@
         <option value="uk">Українська</option>
       </select></label>
       <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
-      <button id="fullscreenBtn" data-i18n="fullscreen">Fullscreen</button>
-      <button id="saveBtn" style="display:none;" data-i18n="saveBtn">Сохранить</button>
-      <button id="settingsMenuBtn" data-i18n="exitReplay">В меню</button>
-      <button id="settingsCloseBtn" data-i18n="settingsClose">Закрыть</button>
+      <button id="fullscreenBtn" class="game-btn" data-i18n="fullscreen">Fullscreen</button>
+      <button id="saveBtn" class="game-btn" style="display:none;" data-i18n="saveBtn">Сохранить</button>
+      <button id="settingsMenuBtn" class="game-btn" data-i18n="exitReplay">В меню</button>
+      <button id="settingsCloseBtn" class="game-btn" data-i18n="settingsClose">Закрыть</button>
     </div>
   </div>
 
   <div id="loadOverlay">
     <div class="panel">
       <div id="loadList"></div>
-      <button id="loadCloseBtn" data-i18n="settingsClose">Закрыть</button>
+      <button id="loadCloseBtn" class="game-btn" data-i18n="settingsClose">Закрыть</button>
     </div>
   </div>
 

--- a/js/core.js
+++ b/js/core.js
@@ -133,6 +133,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
   const BASE_ROWS = 20, BASE_COLS = 30;
   let ROWS = BASE_ROWS, COLS = BASE_COLS;
   let mapSize = 'medium';
+  const MIN_INFO_HEIGHT = 140;
   let aiMode = false, aiLevel = 2;
   const TERRAIN = { PLAIN:0, WATER:1, FOREST:2, HILL:3, MOUNTAIN:4 };
   const TERR_COL  = ['#a6d88c','#6db6f8','#2e8b3d','#d4b55c','#8d8d8d'];
@@ -449,14 +450,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
   // === Resize ===
   window.addEventListener('resize',()=>{
     const infoPanel = document.getElementById('infoPanel');
-    const infoH = infoPanel.offsetHeight;
     const size = Math.floor(Math.min(
       window.innerWidth / COLS,
-      (window.innerHeight - infoH) / ROWS
+      (window.innerHeight - MIN_INFO_HEIGHT) / ROWS
     ));
     cellW = cellH = size;
     canvas.width  = cellW * COLS;
     canvas.height = cellH * ROWS;
+    const panelH = Math.max(MIN_INFO_HEIGHT, window.innerHeight - canvas.height);
+    infoPanel.style.height = panelH + 'px';
     infoPanel.style.bottom = '0';
     updateAll();
   });
@@ -1549,11 +1551,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
       row.className='load-item';
       const date=new Date(s.timestamp).toLocaleString();
       row.innerHTML = `<span>${date}</span>`+
-        `<span><button data-key="${s.key}" class="loadBtn" data-i18n="loadSave">Загрузить</button>`+
-        `<button data-key="${s.key}" class="delBtn" data-i18n="deleteSave">Удалить</button></span>`;
+        `<span><button data-key="${s.key}" class="loadBtn game-btn" data-i18n="loadSave">Загрузить</button>`+
+        `<button data-key="${s.key}" class="delBtn game-btn" data-i18n="deleteSave">Удалить</button></span>`;
       loadList.appendChild(row);
     });
     applyStrings();
+    loadList.querySelectorAll('button').forEach(btn=>{
+      btn.addEventListener('mouseenter',()=>playAudio(uiHoverSfx));
+      btn.addEventListener('click',()=>playAudio(uiClickSfx));
+    });
   }
 
   loadList.addEventListener('click',e=>{


### PR DESCRIPTION
## Summary
- expand settings overlay horizontally and adjust button styles
- slightly alter settings close button colour
- make all UI buttons share the same animation style
- stretch stats panel to fill space under the map

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb9d6e11c83328ea968a9fef544fd