### PR TITLE
Update settings close button color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -536,15 +536,15 @@ h1 {
 }
 
 #settingsCloseBtn {
-  background: #c7a86f;
-  border-color: #c7a86f;
+  background: #9d8260;
+  border-color: #9d8260;
   color: #2e2e2e;
   margin-top: 20px;
 }
 
 #settingsCloseBtn:hover {
-  background: #d1b379;
-  border-color: #d1b379;
+  background: #ad9270;
+  border-color: #ad9270;
 }
 
 #legendOverlay .panel,


### PR DESCRIPTION
## Summary
- use a new muted color for `#settingsCloseBtn`
- keep hover animation and adjust the hover background shade

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ec82f10c883328204217cff3dc5fb