### PR TITLE
Add pulseLift animation to start header button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,6 +27,11 @@ h1 {
   50% { transform: scale(1.05); }
 }
 
+@keyframes pulseLift {
+  0%,100% { transform: translateY(-50%) scale(1); }
+  50% { transform: translateY(-50%) scale(1.05); }
+}
+
 .game-btn {
   margin: 6px;
   padding: 10px 20px;
@@ -95,6 +100,10 @@ h1 {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
+}
+
+#startHeader button:hover:not(:disabled) {
+  animation: pulseLift 0.4s ease;
 }
 
 #summary {


### PR DESCRIPTION
## Summary
- add `pulseLift` animation using `translateY(-50%)` and scale
- animate `#startHeader button` with the new keyframes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ecaca79d88332a0998288be3eb331