### PR TITLE
Wrap audio controls with container and disable sliders

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -525,6 +525,16 @@ h1 {
   text-align: left;
 }
 
+#settingsOverlay .volume-setting {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#settingsOverlay .volume-setting input[type="range"] {
+  flex: 1;
+}
+
 #settingsOverlay input[type="range"],
 #settingsOverlay select {
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -126,10 +126,18 @@
   <div id="settingsOverlay">
     <div class="panel">
       <label><input type="checkbox" id="simplifyChk"/> <span data-i18n="simplify">Упрощённый вид</span></label>
-      <label><input type="checkbox" id="musicEnable"/> <span data-i18n="music">Музыка</span></label>
-      <label data-i18n="musicVolume">Громкость музыки: <input type="range" id="musicVolume" min="0" max="1" step="0.01" value="0.5"/></label>
-      <label><input type="checkbox" id="sfxEnable"/> <span data-i18n="sfx">Звуковые эффекты</span></label>
-      <label data-i18n="sfxVolume">Громкость эффектов: <input type="range" id="sfxVolume" min="0" max="1" step="0.01" value="0.5"/></label>
+      <div class="volume-setting">
+        <input type="checkbox" id="musicEnable"/>
+        <span data-i18n="music">Музыка</span>
+        <span data-i18n="musicVolume">Громкость музыки:</span>
+        <input type="range" id="musicVolume" min="0" max="1" step="0.01" value="0.5"/>
+      </div>
+      <div class="volume-setting">
+        <input type="checkbox" id="sfxEnable"/>
+        <span data-i18n="sfx">Звуковые эффекты</span>
+        <span data-i18n="sfxVolume">Громкость эффектов:</span>
+        <input type="range" id="sfxVolume" min="0" max="1" step="0.01" value="0.5"/>
+      </div>
       <label data-i18n="langLabel">Language: <select id="langSelect">
         <option value="ru">Русский</option>
         <option value="en">English</option>

--- a/js/core.js
+++ b/js/core.js
@@ -1480,8 +1480,10 @@ window.addEventListener('DOMContentLoaded', ()=>{
   settingsBtn.addEventListener('click',()=>{
     simplifyChk.checked = simpleView;
     musicEnableEl.checked = musicEnabled;
+    musicVolumeEl.disabled = !musicEnabled;
     musicVolumeEl.value = musicVolume;
     sfxEnableEl.checked = sfxEnabled;
+    sfxVolumeEl.disabled = !sfxEnabled;
     sfxVolumeEl.value = sfxVolume;
     langSelect.value = lang;
     hintsChk.checked = tooltipEnabled;
@@ -1505,8 +1507,10 @@ window.addEventListener('DOMContentLoaded', ()=>{
   async function applySettings(){
     simpleView = simplifyChk.checked;
     musicEnabled = musicEnableEl.checked;
+    musicVolumeEl.disabled = !musicEnabled;
     musicVolume = parseFloat(musicVolumeEl.value);
     sfxEnabled = sfxEnableEl.checked;
+    sfxVolumeEl.disabled = !sfxEnabled;
     sfxVolume = parseFloat(sfxVolumeEl.value);
     lang = langSelect.value;
     loadLangStrings();


### PR DESCRIPTION
## Summary
- group music and sfx controls in one element each
- style new volume-setting containers
- disable sliders when their checkboxes are unchecked

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed80be52c83328dcfcf6caec9c492