### PR TITLE
Fix capture after building destruction

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1280,23 +1280,18 @@ window.addEventListener('DOMContentLoaded', ()=>{
             recordEvent(t('noAttackWater'));
             sel=null; zoneMap=null; zoneList=[]; updateAll(); return;
           }
-          if(bldTgt.hp<=0){
-            const from={r:sel.r,c:sel.c};
-            sel.mp=zoneMap.rem[bldTgt.r][bldTgt.c]>=0?zoneMap.rem[bldTgt.r][bldTgt.c]:0;
-            if(!aiMode) addReplay({type:'move',unit:sel,from,to:{r:bldTgt.r,c:bldTgt.c}});
-            animateMove(sel,sel.r,sel.c,bldTgt.r,bldTgt.c);
-            sel.r=bldTgt.r; sel.c=bldTgt.c;
-            attemptCapture(sel,bldTgt);
-            recordEvent(`Перемещён ${UNIT_LABELS[sel.type]}`);
-            if(sel.mp>0){ let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list; }
-            else { sel=null; zoneMap=null; zoneList=[]; }
-            updateAll(); return;
-          }
           sel.mp=0;
           const {dmg}=doAttackBuilding(sel,bldTgt);
           if(!aiMode) addReplay({type:'attack',target:bldTgt});
           playAudio(attackSfx);
           animateShake(bldTgt);
+          let destroyed = bldTgt.hp<=0;
+          if(destroyed && UNIT_TYPES[sel.type].range===1){
+            if(!aiMode) addReplay({type:'move',unit:sel,from:{r:sel.r,c:sel.c},to:{r:bldTgt.r,c:bldTgt.c}});
+            animateMove(sel,sel.r,sel.c,bldTgt.r,bldTgt.c);
+            sel.r=bldTgt.r; sel.c=bldTgt.c;
+            attemptCapture(sel,bldTgt);
+          }
           recordEvent(`${UNIT_LABELS[sel.type]} атаковал ${BUILD_LABELS[bldTgt.type]} за ${dmg}`);
           if(sel.mp>0){
             let cz=computeZone(sel); zoneMap=cz; zoneList=cz.list;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -287,6 +287,8 @@ describe('Fog of Conquest core', () => {
     doAttackBuilding(archer, base);
     expect(base.owner).toBe(1);
     expect(base.hp).toBe(0);
+    expect(archer.r).toBe(0);
+    expect(archer.c).toBe(0);
     window.attemptCapture(archer, base);
     expect(base.owner).toBe(1);
     // move archer onto the building and capture
@@ -295,6 +297,30 @@ describe('Fog of Conquest core', () => {
     window.attemptCapture(archer, base);
     expect(base.owner).toBe(2);
     expect(base.hp).toBe(BUILD_TYPES.base.hpMax);
+  });
+
+  test('swordsman auto moves onto destroyed building', () => {
+    const { map, TERRAIN, buildings, units, state, BUILD_TYPES, UNIT_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    units.length = 0;
+    buildings.length = 0;
+    for(let r=0;r<3;r++)for(let c=0;c<3;c++) map[r][c]=TERRAIN.PLAIN;
+    buildings.push({r:0,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen,hp:1});
+    units.push({id:1,r:0,c:0,owner:2,type:'swordsman',hp:UNIT_TYPES.swordsman.hpMax,mp:UNIT_TYPES.swordsman.move,startR:0,startC:0});
+    state.currentPlayer = 2;
+    const canvas = document.getElementById('canvas');
+    canvas.getBoundingClientRect = () => ({left:0,top:0,width:canvas.width,height:canvas.height});
+    const cellW = canvas.width / map[0].length;
+    const cellH = canvas.height / map.length;
+    const click = (r,c) => canvas.dispatchEvent(new window.MouseEvent('click',{clientX:(c+0.5)*cellW,clientY:(r+0.5)*cellH}));
+    click(0,0);
+    click(0,1);
+    const base = buildings[0];
+    const sword = units[0];
+    expect(base.owner).toBe(2);
+    expect(base.hp).toBe(BUILD_TYPES.base.hpMax);
+    expect(sword.r).toBe(base.r);
+    expect(sword.c).toBe(base.c);
   });
 
   test('mage highlights adjacent injured allies', async () => {


### PR DESCRIPTION
## Summary
- prevent ranged units from auto-capturing destroyed buildings
- auto-move melee units into destroyed buildings
- add test coverage for capture flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed9a140a88332b7e4f398da805a60