### PR TITLE
Fix dropdown arrow overlapping text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -161,6 +161,7 @@ h1 {
 .dropdown-toggle {
   margin: 0 6px;
   padding: 6px 10px;
+  padding-right: 24px; /* ensure space for the triangle */
   border-radius: 4px;
   font-family: 'Lora', serif;
   border: 1px solid #555;


### PR DESCRIPTION
## Summary
- adjust custom dropdown CSS to prevent arrow from covering text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee23745e883328664c672b7cf95ef