### PR TITLE
Add replay controls with video export

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a small browser strategy game. Interface texts are available in Russian, English and now Ukrainian.
 
 Run `npm install` and `npm test` to execute unit tests.
+
+After winning a match you can watch a replay. Use the slider to seek to any
+moment, restart the replay or change playback speed. A "Save video" button lets
+you export the replay as a WebM file.

--- a/css/style.css
+++ b/css/style.css
@@ -627,6 +627,13 @@ h1 {
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+#replayControls input[type="range"] {
+  flex: 1 1 100%;
+  margin-bottom: 6px;
 }
 #exitReplayBtn {
   position: absolute;

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -52,4 +52,6 @@
   ,"newGame": "Start new game"
   ,"fullscreen": "Fullscreen"
   ,"replaySide": "Switch side"
+  ,"replayRestart": "Restart"
+  ,"saveReplay": "Save video"
 }

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -52,4 +52,6 @@
   ,"newGame": "Новая игра"
   ,"fullscreen": "Полный экран"
   ,"replaySide": "Сменить сторону"
+  ,"replayRestart": "С начала"
+  ,"saveReplay": "Сохранить видео"
 }

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -52,4 +52,6 @@
   ,"newGame": "Нова гра"
   ,"fullscreen": "Повний екран"
   ,"replaySide": "Змінити сторону"
+  ,"replayRestart": "Почати спочатку"
+  ,"saveReplay": "Зберегти відео"
 }

--- a/index.html
+++ b/index.html
@@ -107,6 +107,8 @@
 
   <div id="replayOverlay">
     <div id="replayControls">
+      <input id="replaySeek" type="range" min="0" value="0">
+      <button id="replayRestartBtn" class="game-btn" data-i18n="replayRestart">Restart</button>
       <button class="speedBtn game-btn" data-speed="0">0×</button>
       <button class="speedBtn game-btn" data-speed="1">1×</button>
       <button class="speedBtn game-btn" data-speed="2">2×</button>
@@ -114,6 +116,7 @@
       <button class="speedBtn game-btn" data-speed="4">4×</button>
       <button class="speedBtn game-btn" data-speed="5">5×</button>
       <button id="replaySideBtn" class="game-btn" data-i18n="replaySide">Сменить сторону</button>
+      <button id="saveReplayBtn" class="game-btn" data-i18n="saveReplay">Save video</button>
     </div>
     <button id="exitReplayBtn" class="game-btn" data-i18n="exitReplay">В меню</button>
   </div>

--- a/js/core.js
+++ b/js/core.js
@@ -88,6 +88,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
         victoryMenuBtn = document.getElementById('victoryMenuBtn'),
         replayOverlay = document.getElementById('replayOverlay'),
         replayControls = document.getElementById('replayControls'),
+        replaySeek = document.getElementById('replaySeek'),
+        replayRestartBtn = document.getElementById('replayRestartBtn'),
+        saveReplayBtn = document.getElementById('saveReplayBtn'),
         exitReplayBtn = document.getElementById('exitReplayBtn'),
         endTurnBtn  = document.getElementById('endTurnBtn'),
         leftStats   = document.getElementById('leftStats'),
@@ -354,10 +357,13 @@ window.addEventListener('DOMContentLoaded', ()=>{
       replayEvents = [],
       replaySpeed = 1,
       replayPaused = false,
+      replayIndex = 0,
       runReplayStep = null,
       replaySide = null,
       currentReplaySnapshot = null,
-      tooltipEnabled = false;
+      tooltipEnabled = false,
+      videoRecorder = null,
+      recordedChunks = [];
 
   Object.assign(window, { spawnZones });
 
@@ -381,7 +387,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
     UNIT_TYPES, BUILD_TYPES,
     UNIT_LABELS, BUILD_LABELS,
     aiLevel,
-    fogSnapshot
+    fogSnapshot,
+    replayEvents
   });
 
   let cellW, cellH;
@@ -738,7 +745,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
     damageBuilding,
     attemptCapture,
     resetState
-  , saveGame, loadGameData, listSaves, deleteSave });
+  , saveGame, loadGameData, listSaves, deleteSave,
+    startMatchReplay, stopMatchReplay, seekReplay });
 
   // === LOS ===
   function hasLOS(r0,c0,r1,c1,{forestBlock=true}={}){
@@ -1465,6 +1473,21 @@ window.addEventListener('DOMContentLoaded', ()=>{
     });
   }
 
+  if(replaySeek){
+    replaySeek.addEventListener('input',()=>{
+      seekReplay(parseInt(replaySeek.value,10));
+    });
+  }
+  if(replayRestartBtn){
+    replayRestartBtn.addEventListener('click',()=>{
+      replayPaused = false;
+      seekReplay(0);
+    });
+  }
+  if(saveReplayBtn){
+    saveReplayBtn.addEventListener('click', recordReplayVideo);
+  }
+
   skipReplayBtn.addEventListener('click', stopReplay);
 
   hintsChk.addEventListener('change',()=>{
@@ -1695,29 +1718,79 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   function startMatchReplay(){
     if(!replayEvents.length) return;
-    let i=1;
+    replayIndex = 0;
     replaySpeed = 1;
     replayPaused = false;
     revealAll = true;
     replaySide = 1;
     currentReplaySnapshot = replayEvents[0].snapshot;
     applySnapshot(currentReplaySnapshot);
+    if(replaySeek){
+      replaySeek.max = replayEvents.length - 1;
+      replaySeek.value = 0;
+    }
     replayOverlay.style.display='flex';
     runReplayStep = function(){
-      if(replayPaused || i>=replayEvents.length) return;
-      const ev = replayEvents[i++];
+      if(replayPaused || replayIndex >= replayEvents.length - 1){
+        if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();
+        return;
+      }
+      replayIndex++;
+      const ev = replayEvents[replayIndex];
       handleReplayAction(ev.action);
       const base = ev.action ? (ev.action.type==='move'?300:ev.action.type==='attack'?150:250) : 400;
       replayTimer = setTimeout(()=>{
         currentReplaySnapshot = ev.snapshot;
         applySnapshot(ev.snapshot);
+        if(replaySeek) replaySeek.value = replayIndex;
         runReplayStep();
       }, base / replaySpeed);
     };
     runReplayStep();
   }
+
+  function recordReplayVideo(){
+    if(videoRecorder && videoRecorder.state !== 'inactive'){
+      videoRecorder.stop();
+      return;
+    }
+    const stream = canvas.captureStream();
+    recordedChunks = [];
+    try{
+      videoRecorder = new MediaRecorder(stream);
+    }catch(e){
+      return;
+    }
+    videoRecorder.ondataavailable = e => {
+      if(e.data && e.data.size) recordedChunks.push(e.data);
+    };
+    videoRecorder.onstop = () => {
+      const blob = new Blob(recordedChunks, {type:'video/webm'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'replay.webm';
+      a.click();
+    };
+    videoRecorder.start();
+    seekReplay(0);
+  }
+
+  function seekReplay(idx){
+    if(!replayEvents.length) return;
+    if(idx < 0) idx = 0;
+    if(idx > replayEvents.length - 1) idx = replayEvents.length - 1;
+    replayIndex = idx;
+    if(replaySeek) replaySeek.value = replayIndex;
+    currentReplaySnapshot = replayEvents[replayIndex].snapshot;
+    applySnapshot(currentReplaySnapshot);
+    if(!replayPaused && typeof runReplayStep === 'function'){
+      if(replayTimer){ clearTimeout(replayTimer); replayTimer = null; }
+      runReplayStep();
+    }
+  }
   function stopMatchReplay(){
     if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
+    if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();
     replayOverlay.style.display='none';
     runReplayStep = null;
     replayPaused = false;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -498,4 +498,19 @@ describe('Fog of Conquest core', () => {
       if(!neighbours) isolated[t]++;
     }
   });
+
+  test('replay UI elements exist', () => {
+    document.getElementById('twoBtn').click();
+    expect(document.getElementById('replaySeek')).toBeTruthy();
+    expect(document.getElementById('replayRestartBtn')).toBeTruthy();
+    expect(document.getElementById('saveReplayBtn')).toBeTruthy();
+  });
+
+  test('replaySeek max reflects event count', () => {
+    document.getElementById('twoBtn').click();
+    window.startMatchReplay();
+    const max = parseInt(document.getElementById('replaySeek').max,10);
+    expect(max).toBeGreaterThanOrEqual(0);
+    window.stopMatchReplay();
+  });
 });


### PR DESCRIPTION
## Summary
- add slider, restart and save buttons for match replays
- update styles for new replay controls
- export new translation keys
- implement replay seeking and video recording in `core.js`
- document replay features in README
- test presence of new UI controls

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee725de908332b82643483c5e51af