### PR TITLE
Capture buildings on destruction

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1105,7 +1105,10 @@ window.addEventListener('DOMContentLoaded', ()=>{
   function damageBuilding(b, newOwner, dmg=1){
     if(!b) return;
     b.hp -= dmg;
-    if(b.hp <= 0) b.hp = 0;
+    if(b.hp <= 0){
+      b.hp = 0;
+      b.owner = newOwner;
+    }
   }
 
   function attemptCapture(unit, building){

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -232,6 +232,16 @@ describe('Fog of Conquest core', () => {
     expect(state.gold[2]).toBe(7);
   });
 
+  test('destroying a building captures it for the attacker', () => {
+    const { buildings, damageBuilding, BUILD_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    const base = buildings.find(b => b.owner === 1 && b.type === 'base');
+    base.hp = 1;
+    damageBuilding(base, 2, 1);
+    expect(base.hp).toBe(0);
+    expect(base.owner).toBe(2);
+  });
+
   test('building takes damage and is captured after repeated occupation', () => {
     const { map, TERRAIN, buildings, units, state, BUILD_TYPES, UNIT_TYPES } = window;
     document.getElementById('twoBtn').click();
@@ -260,7 +270,7 @@ describe('Fog of Conquest core', () => {
     for(let i=1;i<BUILD_TYPES.base.hpMax;i++){
       window.damageBuilding(buildings[0],2);
     }
-    expect(buildings[0].owner).toBe(1);
+    expect(buildings[0].owner).toBe(2);
     expect(buildings[0].hp).toBe(0);
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);
@@ -285,12 +295,12 @@ describe('Fog of Conquest core', () => {
     window.attemptCapture(archer, base);
     expect(base.owner).toBe(1);
     doAttackBuilding(archer, base);
-    expect(base.owner).toBe(1);
+    expect(base.owner).toBe(2);
     expect(base.hp).toBe(0);
     expect(archer.r).toBe(0);
     expect(archer.c).toBe(0);
     window.attemptCapture(archer, base);
-    expect(base.owner).toBe(1);
+    expect(base.owner).toBe(2);
     // move archer onto the building and capture
     archer.r = base.r;
     archer.c = base.c;
@@ -415,7 +425,7 @@ describe('Fog of Conquest core', () => {
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(1);
     for(let i=1;i<BUILD_TYPES.base.hpMax;i++) window.damageBuilding(buildings[0],2);
-    expect(buildings[0].owner).toBe(1);
+    expect(buildings[0].owner).toBe(2);
     expect(buildings[0].hp).toBe(0);
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);


### PR DESCRIPTION
## Summary
- switch building owner when damage reduces HP to zero
- update combat tests for new capture mechanics
- test capturing occurs immediately when a building is destroyed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685efed7f9ac83328ba8ace2fae260b2