### PR TITLE
Switch default language to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no,viewport-fit=cover"/>

--- a/js/core.js
+++ b/js/core.js
@@ -172,7 +172,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
       sfxVolume = 0.5,
       musicEnabled = false,
       sfxEnabled = true,
-      lang = 'ru',
+      lang = 'en',
       strings = {};
 
   function loadSettings(){

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -398,8 +398,8 @@ describe('Fog of Conquest core', () => {
     const beforeText=reveal.textContent;
     reveal.click();
     const afterText=reveal.textContent;
-    expect(beforeText).toBe('Показать карту');
-    expect(afterText).toBe('Скрыть карту');
+    expect(beforeText).toBe('Show map');
+    expect(afterText).toBe('Hide map');
   });
 
   test('combat and capture work in beta mode', () => {


### PR DESCRIPTION
## Summary
- default the HTML lang tag to `en`
- default core language variable to `en`
- update tests for English language strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f00198678833286fef0933d15fdf2