### PR TITLE
Improve replay speed control

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,6 +64,11 @@ h1 {
   cursor: default;
 }
 
+.speed-selected {
+  background: #d8c18f;
+  border-color: #d8c18f;
+}
+
 
 #startPanel {
   position: fixed;

--- a/js/core.js
+++ b/js/core.js
@@ -129,6 +129,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
         newGameBtn   = document.getElementById('newGameBtn'),
         newGameOptions = document.getElementById('newGameOptions'),
         replaySideBtn = document.getElementById('replaySideBtn');
+  const speedBtns = document.querySelectorAll('.speedBtn');
 
   // === Константы ===
   // default orientation switched to horizontal
@@ -1454,9 +1455,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
     goToMenu();
   });
 
-  document.querySelectorAll('.speedBtn').forEach(btn=>{
+  speedBtns.forEach(btn=>{
     btn.addEventListener('click',()=>{
       const sp = parseFloat(btn.dataset.speed);
+      speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+      btn.classList.add('speed-selected');
       if(sp === 0){
         replaySpeed = 0;
         replayPaused = true;
@@ -1732,6 +1735,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
       replaySeek.value = 0;
     }
     replayOverlay.style.display='flex';
+    if(speedBtns.length){
+      speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+      const def=document.querySelector('.speedBtn[data-speed="1"]');
+      if(def) def.classList.add('speed-selected');
+    }
     runReplayStep = function(){
       if(replayPaused || replayIndex >= replayEvents.length - 1){
         if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();


### PR DESCRIPTION
## Summary
- style selected replay speed buttons
- show default speed selection at start of replay
- toggle speed selection styling when a speed button is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f00f864b48332a82348327c15415a