### PR TITLE
Add collapsible replay controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Run `npm install` and `npm test` to execute unit tests.
 
 After winning a match you can watch a replay. Use the slider to seek to any
 moment, restart the replay or change playback speed. A "Save video" button lets
-you export the replay as a WebM file.
+you export the replay as a WebM file. Replay controls can now be collapsed into
+a single icon with a dedicated pause/play button for compact viewing.

--- a/css/style.css
+++ b/css/style.css
@@ -636,9 +636,23 @@ h1 {
   flex-wrap: wrap;
   gap: 6px;
 }
+#replayControls.collapsed {
+  left: 10px;
+  transform: none;
+  padding: 6px;
+}
+#replayControls.collapsed > :not(#replayToggleBtn) {
+  display: none;
+}
 #replayControls input[type="range"] {
   flex: 1 1 100%;
   margin-bottom: 6px;
+}
+#replayPauseBtn {
+  position: absolute;
+  top: 10px;
+  left: 50px;
+  display: none;
 }
 #exitReplayBtn {
   position: absolute;

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -54,4 +54,6 @@
   ,"replaySide": "Switch side"
   ,"replayRestart": "Restart"
   ,"saveReplay": "Save video"
+  ,"replayCollapse": "Hide controls"
+  ,"replayExpand": "Show controls"
 }

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -54,4 +54,6 @@
   ,"replaySide": "Сменить сторону"
   ,"replayRestart": "С начала"
   ,"saveReplay": "Сохранить видео"
+  ,"replayCollapse": "Свернуть"
+  ,"replayExpand": "Развернуть"
 }

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -54,4 +54,6 @@
   ,"replaySide": "Змінити сторону"
   ,"replayRestart": "Почати спочатку"
   ,"saveReplay": "Зберегти відео"
+  ,"replayCollapse": "Згорнути"
+  ,"replayExpand": "Розгорнути"
 }

--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
 
   <div id="replayOverlay">
     <div id="replayControls">
+      <button id="replayToggleBtn" class="game-btn" data-i18n-title="replayCollapse">☰</button>
       <input id="replaySeek" type="range" min="0" value="0">
       <button id="replayRestartBtn" class="game-btn" data-i18n="replayRestart">Restart</button>
       <button class="speedBtn game-btn" data-speed="0">0×</button>
@@ -118,6 +119,7 @@
       <button id="replaySideBtn" class="game-btn" data-i18n="replaySide">Сменить сторону</button>
       <button id="saveReplayBtn" class="game-btn" data-i18n="saveReplay">Save video</button>
     </div>
+    <button id="replayPauseBtn" class="game-btn">⏸</button>
     <button id="exitReplayBtn" class="game-btn" data-i18n="exitReplay">В меню</button>
   </div>
 

--- a/js/core.js
+++ b/js/core.js
@@ -128,7 +128,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
         fullscreenBtn = document.getElementById('fullscreenBtn'),
         newGameBtn   = document.getElementById('newGameBtn'),
         newGameOptions = document.getElementById('newGameOptions'),
-        replaySideBtn = document.getElementById('replaySideBtn');
+        replaySideBtn = document.getElementById('replaySideBtn'),
+        replayToggleBtn = document.getElementById('replayToggleBtn'),
+        replayPauseBtn = document.getElementById('replayPauseBtn');
   const speedBtns = document.querySelectorAll('.speedBtn');
 
   // === Константы ===
@@ -388,7 +390,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
     UNIT_LABELS, BUILD_LABELS,
     aiLevel,
     fogSnapshot,
-    replayEvents
+    replayEvents,
+    replayPaused
   });
 
   let cellW, cellH;
@@ -1489,6 +1492,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
         replayPaused = false;
         if(wasPaused && typeof runReplayStep === 'function') runReplayStep();
       }
+      updateReplayPauseBtn();
+      window.replayPaused = replayPaused;
     });
   });
   if(replaySideBtn){
@@ -1507,10 +1512,48 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayRestartBtn.addEventListener('click',()=>{
       replayPaused = false;
       seekReplay(0);
+      window.replayPaused = replayPaused;
+      updateReplayPauseBtn();
     });
   }
   if(saveReplayBtn){
     saveReplayBtn.addEventListener('click', recordReplayVideo);
+  }
+
+  if(replayToggleBtn){
+    replayToggleBtn.addEventListener('click',()=>{
+      const collapsed = replayControls.classList.toggle('collapsed');
+      if(collapsed){
+        if(replayPauseBtn){ updateReplayPauseBtn(); replayPauseBtn.style.display='block'; }
+        replayToggleBtn.setAttribute('title', t('replayExpand'));
+      }else{
+        if(replayPauseBtn) replayPauseBtn.style.display='none';
+        replayToggleBtn.setAttribute('title', t('replayCollapse'));
+      }
+      window.replayPaused = replayPaused;
+    });
+  }
+
+  function updateReplayPauseBtn(){
+    if(!replayPauseBtn) return;
+    replayPauseBtn.textContent = replayPaused ? '▶' : '⏸';
+  }
+
+  if(replayPauseBtn){
+    replayPauseBtn.addEventListener('click',()=>{
+      if(replayPaused){
+        replayPaused = false;
+        if(replaySpeed===0) replaySpeed = 1;
+        speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+        const def=document.querySelector(`.speedBtn[data-speed="${replaySpeed}"]`);
+        if(def) def.classList.add('speed-selected');
+        if(typeof runReplayStep === 'function') runReplayStep();
+      }else{
+        replayPaused = true;
+      }
+      updateReplayPauseBtn();
+      window.replayPaused = replayPaused;
+    });
   }
 
   skipReplayBtn.addEventListener('click', stopReplay);
@@ -1746,6 +1789,13 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayIndex = 0;
     replaySpeed = 1;
     replayPaused = false;
+    replayControls.classList.remove('collapsed');
+    if(replayPauseBtn){
+      replayPauseBtn.style.display='none';
+      updateReplayPauseBtn();
+    }
+    if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));
+    window.replayPaused = replayPaused;
     revealAll = true;
     replaySide = 1;
     currentReplaySnapshot = replayEvents[0].snapshot;
@@ -1822,8 +1872,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
     if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
     if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();
     replayOverlay.style.display='none';
+    replayControls.classList.remove('collapsed');
+    if(replayPauseBtn){
+      replayPauseBtn.style.display='none';
+      updateReplayPauseBtn();
+    }
+    if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));
     runReplayStep = null;
     replayPaused = false;
+    window.replayPaused = replayPaused;
     replaySide = null;
     revealAll = false;
   }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -605,4 +605,27 @@ describe('Fog of Conquest core', () => {
     expect(max).toBeGreaterThanOrEqual(0);
     window.stopMatchReplay();
   });
+
+  test('replay controls can be collapsed and expanded', () => {
+    document.getElementById('twoBtn').click();
+    window.startMatchReplay();
+    const toggle = document.getElementById('replayToggleBtn');
+    toggle.click();
+    expect(document.getElementById('replayControls').classList.contains('collapsed')).toBe(true);
+    toggle.click();
+    expect(document.getElementById('replayControls').classList.contains('collapsed')).toBe(false);
+    window.stopMatchReplay();
+  });
+
+  test('pause button works when controls collapsed', () => {
+    document.getElementById('twoBtn').click();
+    window.startMatchReplay();
+    document.getElementById('replayToggleBtn').click();
+    const pauseBtn = document.getElementById('replayPauseBtn');
+    pauseBtn.click();
+    expect(window.replayPaused).toBe(true);
+    pauseBtn.click();
+    expect(window.replayPaused).toBe(false);
+    window.stopMatchReplay();
+  });
 });


### PR DESCRIPTION
## Summary
- make replay controls collapsible with a toggle
- show a pause/play button when collapsed
- translate new strings and mention feature in README
- test collapsed replay controls

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f040297208332bb5467f374617dba