### PR TITLE
UI polish and replay fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,7 +40,7 @@ h1 {
   border-radius: 4px;
   color: #2e2e2e;
   cursor: pointer;
-  font: 1em 'Lora', serif;
+  font: 1em 'Cinzel Decorative','Lora', serif;
   font-weight: bold;
   user-select: none;
   -webkit-user-select: none;
@@ -105,6 +105,7 @@ h1 {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
+  transform-origin: center;
 }
 
 #startHeader button:hover:not(:disabled) {
@@ -168,17 +169,16 @@ h1 {
   padding: 6px 10px;
   padding-right: 24px; /* ensure space for the triangle */
   border-radius: 4px;
-  font-family: 'Lora', serif;
-  border: 1px solid #bda46a;
-  background: linear-gradient(#cfc092, #bda46a);
+  font-family: 'Cinzel Decorative','Lora',serif;
+  border: 1px solid #8b6f4d;
+  background: #bda46a;
   color: #2e2e2e;
   cursor: pointer;
   position: relative;
   transition: background 0.3s;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
 }
 .dropdown-toggle:hover {
-  background: linear-gradient(#d8c18f, #c6b47a);
+  background: #d8c18f;
 }
 .dropdown-toggle::after {
   content: ' \25BC';
@@ -192,9 +192,9 @@ h1 {
   top: 100%;
   left: 0;
   right: 0;
-  background: #2e2e2e;
-  border: 1px solid #555;
-  color: #ddd;
+  background: #3a2e1a;
+  border: 1px solid #8b6f4d;
+  color: #eee;
   max-height: 200px;
   overflow-y: auto;
   z-index: 60;
@@ -202,11 +202,11 @@ h1 {
   list-style: none;
   margin: 0;
   padding: 0;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+  box-shadow: none;
 }
 .dropdown.open .dropdown-menu { display: block; }
 .dropdown-menu li { padding: 4px 10px; cursor: pointer; }
-.dropdown-menu li:hover { background: #d8c18f; color: #2e2e2e; }
+.dropdown-menu li:hover { background: #8b6f4d; color: #fff; }
 .dropdown-menu li.focused,
 .dropdown-menu li.selected { background: #bda46a; color: #2e2e2e; }
 #aiPanel {
@@ -584,6 +584,14 @@ h1 {
   gap: 6px;
 }
 
+.settings-group {
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: space-between;
+}
+
 #settingsOverlay .volume-setting input[type="range"] {
   flex: 1;
 }
@@ -608,15 +616,15 @@ h1 {
 }
 
 #settingsCloseBtn {
-  background: #9d8260;
-  border-color: #9d8260;
+  background: #8b6f4d;
+  border-color: #8b6f4d;
   color: #2e2e2e;
   margin-top: 20px;
 }
 
 #settingsCloseBtn:hover {
-  background: #ad9270;
-  border-color: #ad9270;
+  background: #9c805d;
+  border-color: #9c805d;
 }
 
 #legendOverlay .panel,
@@ -651,7 +659,7 @@ h1 {
 #replayPauseBtn {
   position: absolute;
   top: 10px;
-  left: 50px;
+  left: 100px;
   display: none;
 }
 #exitReplayBtn {

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -29,7 +29,7 @@
   "musicVolume": "Music volume:",
   "sfx": "Sound effects",
   "sfxVolume": "Effects volume:",
-  "langLabel": "Language:",
+  "langLabel": "Language",
   "settingsClose": "Close",
   "legendBtnTitle": "Legend",
   "settingsBtn": "Settings",

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -29,7 +29,7 @@
   "musicVolume": "Громкость музыки:",
   "sfx": "Звуковые эффекты",
   "sfxVolume": "Громкость эффектов:",
-  "langLabel": "Язык:",
+  "langLabel": "Язык",
   "settingsClose": "Закрыть",
   "legendBtnTitle": "Легенда",
   "settingsBtn": "Настройки",

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -29,7 +29,7 @@
   "musicVolume": "Гучність музики:",
   "sfx": "Звукові ефекти",
   "sfxVolume": "Гучність ефектів:",
-  "langLabel": "Мова:",
+  "langLabel": "Мова",
   "settingsClose": "Закрити",
   "legendBtnTitle": "Легенда",
   "settingsBtn": "Налаштування",

--- a/index.html
+++ b/index.html
@@ -110,7 +110,6 @@
       <button id="replayToggleBtn" class="game-btn" data-i18n-title="replayCollapse">☰</button>
       <input id="replaySeek" type="range" min="0" value="0">
       <button id="replayRestartBtn" class="game-btn" data-i18n="replayRestart">Restart</button>
-      <button class="speedBtn game-btn" data-speed="0">0×</button>
       <button class="speedBtn game-btn" data-speed="1">1×</button>
       <button class="speedBtn game-btn" data-speed="2">2×</button>
       <button class="speedBtn game-btn" data-speed="3">3×</button>
@@ -130,25 +129,32 @@
 
   <div id="settingsOverlay">
     <div class="panel">
-      <label><input type="checkbox" id="simplifyChk"/> <span data-i18n="simplify">Упрощённый вид</span></label>
-      <div class="volume-setting">
-        <input type="checkbox" id="musicEnable"/>
-        <span data-i18n="music">Музыка</span>
-        <span data-i18n="musicVolume">Громкость музыки:</span>
-        <input type="range" id="musicVolume" min="0" max="1" step="0.01" value="0.5"/>
+      <div class="settings-group">
+        <label><input type="checkbox" id="simplifyChk"/> <span data-i18n="simplify">Упрощённый вид</span></label>
+        <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
       </div>
-      <div class="volume-setting">
-        <input type="checkbox" id="sfxEnable"/>
-        <span data-i18n="sfx">Звуковые эффекты</span>
-        <span data-i18n="sfxVolume">Громкость эффектов:</span>
-        <input type="range" id="sfxVolume" min="0" max="1" step="0.01" value="0.5"/>
+      <div class="settings-group">
+        <div class="volume-setting">
+          <input type="checkbox" id="musicEnable"/>
+          <span data-i18n="music">Музыка</span>
+          <span data-i18n="musicVolume">Громкость музыки:</span>
+          <input type="range" id="musicVolume" min="0" max="1" step="0.01" value="0.5"/>
+        </div>
+        <div class="volume-setting">
+          <input type="checkbox" id="sfxEnable"/>
+          <span data-i18n="sfx">Звуковые эффекты</span>
+          <span data-i18n="sfxVolume">Громкость эффектов:</span>
+          <input type="range" id="sfxVolume" min="0" max="1" step="0.01" value="0.5"/>
+        </div>
       </div>
-      <label data-i18n="langLabel">Language: <select id="langSelect">
-        <option value="ru">Русский</option>
-        <option value="en">English</option>
-        <option value="uk">Українська</option>
-      </select></label>
-      <label><input type="checkbox" id="hintsChk"/> <span data-i18n="tooltip">Подсказки</span></label>
+      <div class="settings-group">
+        <label for="langSelect" data-i18n="langLabel">Language</label>
+        <select id="langSelect">
+          <option value="ru">Русский</option>
+          <option value="en" selected>English</option>
+          <option value="uk">Українська</option>
+        </select>
+      </div>
       <button id="fullscreenBtn" class="game-btn" data-i18n="fullscreen">Fullscreen</button>
       <button id="saveBtn" class="game-btn" style="display:none;" data-i18n="saveBtn">Сохранить</button>
       <button id="settingsMenuBtn" class="game-btn" data-i18n="exitReplay">В меню</button>

--- a/js/core.js
+++ b/js/core.js
@@ -870,9 +870,25 @@ window.addEventListener('DOMContentLoaded', ()=>{
       }
     });
 
+    let animRunning=false;
     units.forEach(u=>{
       if((!F[u.r][u.c]||revealAll)&&S[u.r][u.c]){
         let cx=u.c*cellW+cellW/2, cy=u.r*cellH+cellH/2, rad=Math.min(cellW,cellH)/3;
+        if(u.animMove){
+          let t=Math.min(1,(Date.now()-u.animMove.start)/u.animMove.dur);
+          cx=(u.animMove.fc+(u.animMove.tc-u.animMove.fc)*t)*cellW+cellW/2;
+          cy=(u.animMove.fr+(u.animMove.tr-u.animMove.fr)*t)*cellH+cellH/2;
+          if(t<1) animRunning=true; else delete u.animMove;
+        }
+        if(u.animShake){
+          let t=(Date.now()-u.animShake.start)/u.animShake.dur;
+          if(t<1){
+            let amp=2;
+            cx+=(Math.random()*2-1)*amp;
+            cy+=(Math.random()*2-1)*amp;
+            animRunning=true;
+          } else delete u.animShake;
+        }
         ctx.fillStyle=UNIT_TYPES[u.type].color;
         ctx.beginPath(); ctx.arc(cx,cy,rad,0,2*Math.PI); ctx.fill();
         ctx.lineWidth=0;
@@ -905,6 +921,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
       ctx.strokeStyle='yellow'; ctx.lineWidth=2; ctx.setLineDash([]);
       ctx.strokeRect(sel.c*cellW+2,sel.r*cellH+2,cellW-4,cellH-4);
     }
+    if(animRunning) requestAnimationFrame(redrawSimple);
   }
 
   function redraw(){
@@ -1075,6 +1092,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
         let rr=o.r+d[0], cc=o.c+d[1];
         if(rr<0||rr>=ROWS||cc<0||cc>=COLS) return;
         if(units.some(us=>us.r===rr&&us.c===cc&&us!==u)) return;
+        let bldBlock = buildings.find(b=>b.r===rr&&b.c===cc && b.owner!==u.owner && b.hp>0);
+        if(bldBlock) return;
         let cost=TERR_COST[map[rr][cc]];
         if(cost>o.mp) return;
         let left=o.mp-cost;
@@ -1126,18 +1145,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
     return {dmg};
   }
 
-  function damageBuilding(b, newOwner, dmg=1){
+  function damageBuilding(b, _newOwner, dmg=1){
     if(!b) return;
     b.hp -= dmg;
-    if(b.hp <= 0){
-      b.hp = 0;
-      b.owner = newOwner;
-    }
+    if(b.hp < 0) b.hp = 0;
   }
 
   function attemptCapture(unit, building){
     if(!building) return;
-    if(unit.r===building.r && unit.c===building.c && building.hp<=0){
+    if(unit.r===building.r && unit.c===building.c && building.hp<=0 && building.owner!==unit.owner){
       const baseTaken = (building.gen ?? BUILD_TYPES[building.type].gen) === 0;
       recordEvent(baseTaken
         ? `Захвачена база`
@@ -1483,15 +1499,10 @@ window.addEventListener('DOMContentLoaded', ()=>{
       const sp = parseFloat(btn.dataset.speed);
       speedBtns.forEach(b=>b.classList.remove('speed-selected'));
       btn.classList.add('speed-selected');
-      if(sp === 0){
-        replaySpeed = 0;
-        replayPaused = true;
-      }else{
-        const wasPaused = replayPaused;
-        replaySpeed = sp;
-        replayPaused = false;
-        if(wasPaused && typeof runReplayStep === 'function') runReplayStep();
-      }
+      const wasPaused = replayPaused;
+      replaySpeed = sp;
+      replayPaused = false;
+      if(wasPaused && typeof runReplayStep === 'function') runReplayStep();
       updateReplayPauseBtn();
       window.replayPaused = replayPaused;
     });
@@ -1543,7 +1554,6 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayPauseBtn.addEventListener('click',()=>{
       if(replayPaused){
         replayPaused = false;
-        if(replaySpeed===0) replaySpeed = 1;
         speedBtns.forEach(b=>b.classList.remove('speed-selected'));
         const def=document.querySelector(`.speedBtn[data-speed="${replaySpeed}"]`);
         if(def) def.classList.add('speed-selected');
@@ -1844,14 +1854,20 @@ window.addEventListener('DOMContentLoaded', ()=>{
     videoRecorder.ondataavailable = e => {
       if(e.data && e.data.size) recordedChunks.push(e.data);
     };
-    videoRecorder.onstop = () => {
+  videoRecorder.onstop = () => {
       const blob = new Blob(recordedChunks, {type:'video/webm'});
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
       a.download = 'replay.webm';
       a.click();
     };
-    videoRecorder.start();
+  videoRecorder.start();
+    replayPaused = false;
+    replaySpeed = 1;
+    speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+    const def=document.querySelector('.speedBtn[data-speed="1"]');
+    if(def) def.classList.add('speed-selected');
+    updateReplayPauseBtn();
     seekReplay(0);
   }
 


### PR DESCRIPTION
## Summary
- restyle dropdowns and buttons with medieval colors
- reorganize settings layout and default to English
- add animations in simplified mode
- refine replay recording and remove 0× speed option
- update building capture rules and movement checks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f08288ed08332adef44363a51539b