### PR TITLE
Fix docs for npm install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a small browser strategy game. Interface texts are available in Russian, English and now Ukrainian.
 
 Run `npm install` and `npm test` to execute unit tests.
+Make sure to install dependencies with `npm install` before running `npm test`.
 
 After winning a match you can watch a replay. Use the slider to seek to any
 moment, restart the replay or change playback speed. A "Save video" button lets

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "pretest": "test -d node_modules || npm install",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remind to run `npm install` prior to running tests
- add `pretest` script to install dependencies if missing

## Testing
- `npm test` *(fails: ENETUNREACH while loading fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685f13aa5e90833295defc7b221519e4