### PR TITLE
Fix start header button hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,7 +109,8 @@ h1 {
 }
 
 #startHeader button:hover:not(:disabled) {
-  animation: pulseLift 0.4s ease;
+  animation: pulse 0.4s ease;
+  transform: translateY(-50%);
 }
 
 #summary {


### PR DESCRIPTION
## Summary
- use the same pulse animation on the start screen settings button
- keep the gear icon centered while hovering

## Testing
- `npm install`
- `npm test` *(fails: Could not load Google Fonts, and some core tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685f15b8d570833296b9e1bdb72a07da