### PR TITLE
Add Cyrillic-friendly font

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ html, body {
   touch-action: manipulation;
   background: radial-gradient(#111, #000);
   color: #2e2e2e;
-  font-family: 'MedievalSharp', cursive;
+  font-family: 'MedievalSharp', 'Ruslan Display', 'Lora', serif;
 }
 
 body {
@@ -18,7 +18,7 @@ body {
 }
 
 h1 {
-  font-family: 'Cinzel Decorative','MedievalSharp', cursive;
+  font-family: 'Cinzel Decorative','Ruslan Display','MedievalSharp', cursive;
   margin-top: 0;
 }
 
@@ -40,7 +40,7 @@ h1 {
   border-radius: 4px;
   color: #2e2e2e;
   cursor: pointer;
-  font: 1em 'Cinzel Decorative','Lora', serif;
+  font: 1em 'Cinzel Decorative','Ruslan Display','Lora', serif;
   font-weight: bold;
   user-select: none;
   -webkit-user-select: none;
@@ -82,7 +82,7 @@ h1 {
   flex-direction: column;
   background: radial-gradient(circle at center, #333, #000);
   color: #eee;
-  font: 1.1em 'MedievalSharp', cursive;
+  font: 1.1em 'MedievalSharp','Ruslan Display', cursive;
   z-index: 30;
   text-shadow: 0 0 6px #000;
 }
@@ -170,7 +170,7 @@ h1 {
   padding: 6px 10px;
   padding-right: 24px; /* ensure space for the triangle */
   border-radius: 4px;
-  font-family: 'Cinzel Decorative','Lora',serif;
+  font-family: 'Cinzel Decorative','Ruslan Display','Lora',serif;
   border: 1px solid #8b6f4d;
   background: #bda46a;
   color: #2e2e2e;
@@ -295,7 +295,7 @@ h1 {
   flex-direction: column;
   background: rgba(0, 0, 0, 0.5);
   color: #fff;
-  font: 2em 'MedievalSharp', cursive;
+  font: 2em 'MedievalSharp','Ruslan Display', cursive;
   z-index: 45;
 }
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
   <meta name="theme-color" content="#000000"/>
   <title>Fog of Conquest</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora&family=MedievalSharp&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700&family=MedievalSharp&family=Ruslan+Display&family=Lora&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="css/style.css"/>
   <link rel="icon" type="image/png" href="assets/icon.png" sizes="512x512"/>
   <link rel="apple-touch-icon" href="assets/icon.png" sizes="512x512"/>


### PR DESCRIPTION
## Summary
- load Ruslan Display font for Cyrillic text
- use Ruslan Display as a fallback in major font stacks

## Testing
- `npm test` *(fails: building capture expectations and network font downloads)*

------
https://chatgpt.com/codex/tasks/task_e_685f8db46cf08332a050fae72c5b0f64