### PR TITLE
Add final replay snapshot and video test

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -487,6 +487,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     state.grace = {1:null,2:null};
     state.log   = {1:[],2:[]};
     replayEvents = [];
+    window.replayEvents = replayEvents;
     fogSnapshot = null;
     window.fogSnapshot = fogSnapshot;
     initFog();
@@ -745,10 +746,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
     updateFog,
     nextTurn,
     recordEvent,
+    snapshot,
+    recordTurn,
     damageBuilding,
     attemptCapture,
-    resetState
-  , saveGame, loadGameData, listSaves, deleteSave,
+    resetState,
+    endGame,
+    recordReplayVideo,
+    replayIndex,
+    saveGame, loadGameData, listSaves, deleteSave,
     startMatchReplay, stopMatchReplay, seekReplay });
 
   // === LOS ===
@@ -1145,23 +1151,29 @@ window.addEventListener('DOMContentLoaded', ()=>{
     return {dmg};
   }
 
-  function damageBuilding(b, _newOwner, dmg=1){
+  function damageBuilding(b, newOwner, dmg=1){
     if(!b) return;
     b.hp -= dmg;
-    if(b.hp < 0) b.hp = 0;
+    if(b.hp <= 0){
+      b.hp = 0;
+      if(newOwner!==undefined) b.owner = newOwner;
+    }
   }
 
   function attemptCapture(unit, building){
     if(!building) return;
-    if(unit.r===building.r && unit.c===building.c && building.hp<=0 && building.owner!==unit.owner){
+    if(unit.r===building.r && unit.c===building.c && building.hp<=0){
+      const already = building.owner === unit.owner;
       const baseTaken = (building.gen ?? BUILD_TYPES[building.type].gen) === 0;
-      recordEvent(baseTaken
-        ? `Захвачена база`
-        : `Захвачена добыча (${BUILD_LABELS[building.type]})`);
-      playAudio(captureSfx);
-      building.owner = unit.owner;
+      if(!already){
+        recordEvent(baseTaken
+          ? `Захвачена база`
+          : `Захвачена добыча (${BUILD_LABELS[building.type]})`);
+        playAudio(captureSfx);
+        building.owner = unit.owner;
+        if(!aiMode) addReplay({type:'capture', building});
+      }
       building.hp = BUILD_TYPES[building.type].hpMax;
-      if(!aiMode) addReplay({type:'capture', building});
     }
   }
 
@@ -1196,6 +1208,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   function endGame(w){
     gameOver=true;
+    if(!replayEvents.length || replayEvents[replayEvents.length-1].type!=='end'){
+      replayEvents.push({type:'end', winner:w, snapshot:snapshot()});
+    }
     victoryText.textContent = t('victory').replace('{player}', w);
     victoryOverlay.style.display = 'flex';
   }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -628,4 +628,36 @@ describe('Fog of Conquest core', () => {
     expect(window.replayPaused).toBe(false);
     window.stopMatchReplay();
   });
+
+  test('endGame appends final snapshot event', () => {
+    document.getElementById('twoBtn').click();
+    const { endGame, replayEvents, recordTurn } = window;
+    recordTurn();
+    endGame(1);
+    expect(replayEvents.length).toBeGreaterThan(0);
+    expect(replayEvents[replayEvents.length - 1].type).toBe('end');
+  });
+
+  test('saving a long replay records until the last turn', () => {
+    document.getElementById('twoBtn').click();
+    window.replayEvents.length = 0;
+    for(let i=0;i<20;i++){
+      window.recordTurn();
+    }
+    const canvas = document.getElementById('canvas');
+    canvas.captureStream = () => ({ });
+    window.URL.createObjectURL = () => 'blob:';
+    let started = false, stopped = false;
+    window.MediaRecorder = function(){
+      this.state = 'inactive';
+      this.start = () => { this.state = 'recording'; started = true; };
+      this.stop = () => { this.state = 'inactive'; stopped = true; if(this.onstop) this.onstop(); };
+    };
+    window.startMatchReplay();
+    window.recordReplayVideo();
+    window.seekReplay(window.replayEvents.length - 1);
+    window.stopMatchReplay();
+    expect(started).toBe(true);
+    expect(stopped).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- keep reference to replay events after reset
- export replay index and recording helpers for tests
- capture building ownership when destroyed and allow recapture healing
- add final snapshot when the game ends
- update unit tests to cover replay recording

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f9799f1dc8332a00799f204d83fa3