### PR TITLE
Auto capture move after destroying building

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1345,13 +1345,14 @@ window.addEventListener('DOMContentLoaded', ()=>{
             recordEvent(t('noAttackWater'));
             sel=null; zoneMap=null; zoneList=[]; updateAll(); return;
           }
+          const hadMove = sel.mp>0;
           sel.mp=0;
           const {dmg}=doAttackBuilding(sel,bldTgt);
           if(!aiMode) addReplay({type:'attack',target:bldTgt});
           playAudio(attackSfx);
           animateShake(bldTgt);
           let destroyed = bldTgt.hp<=0;
-          if(destroyed && UNIT_TYPES[sel.type].range===1){
+          if(destroyed && hadMove){
             if(!aiMode) addReplay({type:'move',unit:sel,from:{r:sel.r,c:sel.c},to:{r:bldTgt.r,c:bldTgt.c}});
             animateMove(sel,sel.r,sel.c,bldTgt.r,bldTgt.c);
             sel.r=bldTgt.r; sel.c=bldTgt.c;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -333,6 +333,30 @@ describe('Fog of Conquest core', () => {
     expect(sword.c).toBe(base.c);
   });
 
+  test('archer auto moves onto destroyed building when movement left', () => {
+    const { map, TERRAIN, buildings, units, state, BUILD_TYPES, UNIT_TYPES } = window;
+    document.getElementById('twoBtn').click();
+    units.length = 0;
+    buildings.length = 0;
+    for(let r=0;r<3;r++)for(let c=0;c<3;c++) map[r][c]=TERRAIN.PLAIN;
+    buildings.push({r:0,c:1,owner:1,type:'base',gen:BUILD_TYPES.base.gen,hp:1});
+    units.push({id:1,r:0,c:0,owner:2,type:'archer',hp:UNIT_TYPES.archer.hpMax,mp:UNIT_TYPES.archer.move,startR:0,startC:0});
+    state.currentPlayer = 2;
+    const canvas = document.getElementById('canvas');
+    canvas.getBoundingClientRect = () => ({left:0,top:0,width:canvas.width,height:canvas.height});
+    const cellW = canvas.width / map[0].length;
+    const cellH = canvas.height / map.length;
+    const click = (r,c) => canvas.dispatchEvent(new window.MouseEvent('click',{clientX:(c+0.5)*cellW,clientY:(r+0.5)*cellH}));
+    click(0,0);
+    click(0,1);
+    const base = buildings[0];
+    const archer = units[0];
+    expect(base.owner).toBe(2);
+    expect(base.hp).toBe(BUILD_TYPES.base.hpMax);
+    expect(archer.r).toBe(base.r);
+    expect(archer.c).toBe(base.c);
+  });
+
   test('mage highlights adjacent injured allies', async () => {
     const draws = [];
     HTMLCanvasElement.prototype.getContext = () => {


### PR DESCRIPTION
## Summary
- allow capturing moves onto destroyed buildings when attacker had movement left
- test archer auto capture from range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa0f6454883328fa4b5fbb41294b6