### PR TITLE
Update settings close button color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -617,15 +617,15 @@ h1 {
 }
 
 #settingsCloseBtn {
-  background: #8b6f4d;
-  border-color: #8b6f4d;
+  background: #70593c;
+  border-color: #70593c;
   color: #2e2e2e;
   margin-top: 20px;
 }
 
 #settingsCloseBtn:hover {
-  background: #9c805d;
-  border-color: #9c805d;
+  background: #80694b;
+  border-color: #80694b;
 }
 
 #legendOverlay .panel,


### PR DESCRIPTION
## Summary
- tweak settings close button color to a darker shade

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa2724b4483329e3d107bf9c95f4d