### PR TITLE
Enhance speed button style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,6 +67,7 @@ h1 {
 .speed-selected {
   background: #d8c18f;
   border-color: #d8c18f;
+  outline: 2px solid #3a2e1a;
 }
 
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -653,6 +653,22 @@ describe('Fog of Conquest core', () => {
     window.stopMatchReplay();
   });
 
+  test('speed button selection toggles style', () => {
+    document.getElementById('twoBtn').click();
+    window.startMatchReplay();
+    const btn1 = document.querySelector('.speedBtn[data-speed="1"]');
+    const btn2 = document.querySelector('.speedBtn[data-speed="2"]');
+    expect(btn1.classList.contains('speed-selected')).toBe(true);
+    expect(btn2.classList.contains('speed-selected')).toBe(false);
+    btn2.click();
+    expect(btn1.classList.contains('speed-selected')).toBe(false);
+    expect(btn2.classList.contains('speed-selected')).toBe(true);
+    btn1.click();
+    expect(btn1.classList.contains('speed-selected')).toBe(true);
+    expect(btn2.classList.contains('speed-selected')).toBe(false);
+    window.stopMatchReplay();
+  });
+
   test('endGame appends final snapshot event', () => {
     document.getElementById('twoBtn').click();
     const { endGame, replayEvents, recordTurn } = window;


### PR DESCRIPTION
## Summary
- add dark outline to `.speed-selected` for better contrast
- test replay speed button class toggles when clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb5eb53788332bea4c4017e66c39f