### PR TITLE
Move replay pause button into controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -659,7 +659,7 @@ h1 {
   transform: none;
   padding: 6px;
 }
-#replayControls.collapsed > :not(#replayToggleBtn) {
+#replayControls.collapsed > :not(#replayToggleBtn):not(#replayPauseBtn) {
   display: none;
 }
 #replayControls input[type="range"] {
@@ -670,7 +670,7 @@ h1 {
   position: absolute;
   top: 10px;
   left: 100px;
-  display: none;
+  display: block;
 }
 #exitReplayBtn {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -116,8 +116,8 @@
       <button class="speedBtn game-btn" data-speed="5">5×</button>
       <button id="replaySideBtn" class="game-btn" data-i18n="replaySide">Switch side</button>
       <button id="saveReplayBtn" class="game-btn" data-i18n="saveReplay">Save video</button>
+      <button id="replayPauseBtn" class="game-btn">⏸</button>
     </div>
-    <button id="replayPauseBtn" class="game-btn">⏸</button>
     <button id="exitReplayBtn" class="game-btn" data-i18n="exitReplay">Menu</button>
   </div>
 

--- a/js/core.js
+++ b/js/core.js
@@ -1551,10 +1551,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayToggleBtn.addEventListener('click',()=>{
       const collapsed = replayControls.classList.toggle('collapsed');
       if(collapsed){
-        if(replayPauseBtn){ updateReplayPauseBtn(); replayPauseBtn.style.display='block'; }
         replayToggleBtn.setAttribute('title', t('replayExpand'));
       }else{
-        if(replayPauseBtn) replayPauseBtn.style.display='none';
         replayToggleBtn.setAttribute('title', t('replayCollapse'));
       }
       window.replayPaused = replayPaused;
@@ -1817,7 +1815,6 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayPaused = false;
     replayControls.classList.remove('collapsed');
     if(replayPauseBtn){
-      replayPauseBtn.style.display='none';
       updateReplayPauseBtn();
     }
     if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));
@@ -1906,7 +1903,6 @@ window.addEventListener('DOMContentLoaded', ()=>{
     replayOverlay.style.display='none';
     replayControls.classList.remove('collapsed');
     if(replayPauseBtn){
-      replayPauseBtn.style.display='none';
       updateReplayPauseBtn();
     }
     if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));


### PR DESCRIPTION
## Summary
- include pause button inside `#replayControls` so it's always part of the control panel
- ensure `#replayPauseBtn` remains visible when controls are collapsed
- simplify JS logic now that the pause button does not move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbc2327988332abee699ee50b7f97