### PR TITLE
Add Cyrillic font stacks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,6 +12,21 @@ html, body {
   font-family: 'MedievalSharp', 'Ruslan Display', 'Lora', serif;
 }
 
+/* Use a Cyrillic-friendly stack when the document language is Russian or Ukrainian */
+html[lang="ru"],
+html[lang="uk"] {
+  font-family: 'Ruslan Display', 'MedievalSharp', 'Lora', serif;
+}
+
+html[lang="ru"] h1,
+html[lang="uk"] h1,
+html[lang="ru"] .game-btn,
+html[lang="uk"] .game-btn,
+html[lang="ru"] .dropdown-toggle,
+html[lang="uk"] .dropdown-toggle {
+  font-family: 'Ruslan Display', 'Cinzel Decorative', 'MedievalSharp', 'Lora', serif;
+}
+
 body {
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
            env(safe-area-inset-bottom) env(safe-area-inset-left);


### PR DESCRIPTION
## Summary
- support Cyrillic fonts by adding `[lang="ru"]` and `[lang="uk"]` rules in `style.css`
- keep English fonts but prefer `Ruslan Display` for Russian and Ukrainian

## Testing
- `npm test`
- node script to load Ukrainian strings

------
https://chatgpt.com/codex/tasks/task_e_685fc47d3c8883328feb32ff7cabaeb2