### PR TITLE
Add replay history to save data

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -168,7 +168,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   const SETTINGS_KEY = 'focSettings';
   const SAVE_PREFIX = 'focSave_';
-  const SAVE_VERSION = 1;
+  const SAVE_VERSION = 2;
   const isTestEnv = navigator.userAgent.includes('jsdom');
   let simpleView = false,
       musicVolume = 0.5,
@@ -525,7 +525,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
       units,
       state,
       mapSize,
-      nextUnitId
+      nextUnitId,
+      replayEvents
     };
     try{ localStorage.setItem(SAVE_PREFIX+data.timestamp, JSON.stringify(data)); }
     catch(e){}
@@ -540,6 +541,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
       buildings.length = 0; d.buildings.forEach(b=>buildings.push({...b}));
       units.length = 0; d.units.forEach(u=>units.push({...u}));
       Object.assign(state, d.state);
+      if(Array.isArray(d.replayEvents)){
+        replayEvents.length = 0;
+        d.replayEvents.forEach(ev => replayEvents.push(ev));
+        window.replayEvents = replayEvents;
+      }
       mapSize = d.mapSize || mapSize;
       ROWS = map.length; COLS = map[0].length;
       nextUnitId = d.nextUnitId || (Math.max(0,...units.map(u=>u.id))+1);

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -729,4 +729,30 @@ describe('Fog of Conquest core', () => {
     expect(started).toBe(true);
     expect(stopped).toBe(true);
   });
+
+  test('save and load preserves replay history', () => {
+    document.getElementById('twoBtn').click();
+    const store = (() => {
+      let data = {};
+      return {
+        getItem: k => (k in data ? data[k] : null),
+        setItem: (k,v) => { data[k] = String(v); },
+        removeItem: k => { delete data[k]; },
+        clear: () => { data = {}; },
+        key: i => Object.keys(data)[i] || null,
+        get length(){ return Object.keys(data).length; }
+      };
+    })();
+    Object.defineProperty(window, 'localStorage', {configurable:true, value:store});
+    window.localStorage.clear();
+    window.replayEvents.length = 0;
+    window.recordTurn();
+    window.recordTurn();
+    const original = JSON.parse(JSON.stringify(window.replayEvents));
+    window.saveGame();
+    const key = window.localStorage.key(0);
+    window.replayEvents.length = 0;
+    window.loadGameData(key);
+    expect(window.replayEvents).toEqual(original);
+  });
 });


### PR DESCRIPTION
## Summary
- bump save version to 2 and save `replayEvents`
- load `replayEvents` when loading a game
- test that replay history persists after save/load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fceb00f148332b5162188fb74ff8a