### PR TITLE
Add wait overlay translation test

### DIFF
--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -771,4 +771,15 @@ describe('Fog of Conquest core', () => {
     expect(msgEn).toMatch(/Player/);
     document.getElementById('yesBtn').click();
   });
+
+  test('langSelect changes wait overlay text', () => {
+    const select = document.getElementById('langSelect');
+    const waitText = document.getElementById('waitText');
+    select.value = 'ru';
+    select.dispatchEvent(new window.Event('input'));
+    expect(waitText.textContent).toMatch(/Подождите/);
+    select.value = 'en';
+    select.dispatchEvent(new window.Event('input'));
+    expect(waitText.textContent).toBe('Please wait...');
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for language switching on wait overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fdb99afc08332b7ae2be4122694a5