### PR TITLE
Fix settings button alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -413,6 +413,9 @@ h1 {
 
 #settingsBtn {
   /* Flex alignment in #controls keeps this centered */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #settingsBtn:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- center the settings button using flexbox so the gear icon doesn't shift
- keep the normal pulse animation on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fdd28489c833293b14dd2125b0d35