### PR TITLE
Fix settings button jump

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,6 +122,9 @@ h1 {
   top: 50%;
   transform: translateY(-50%);
   transform-origin: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #startHeader button:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- keep start menu settings button centered when animating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe6bedcc48332b81dc0b7d4ab9b3b