### PR TITLE
Add WebSocket network utility and tests

### DIFF
--- a/js/network.js
+++ b/js/network.js
@@ -1,0 +1,47 @@
+(function(global){
+  function createEmitter(){
+    const events = {};
+    return {
+      on(event, fn){
+        (events[event]||(events[event]=[])).push(fn);
+      },
+      off(event, fn){
+        if(events[event]) events[event]=events[event].filter(f=>f!==fn);
+      },
+      emit(event, ...args){
+        (events[event]||[]).forEach(fn=>fn(...args));
+      }
+    };
+  }
+
+  function connect(serverUrl){
+    const ws = new global.WebSocket(serverUrl);
+    const emitter = createEmitter();
+
+    ws.addEventListener('open', () => emitter.emit('connected'));
+    ws.addEventListener('message', e => {
+      let data = e.data;
+      try{ data = JSON.parse(e.data); }catch(err){}
+      emitter.emit('message', data);
+    });
+    ws.addEventListener('error', err => emitter.emit('error', err));
+    ws.addEventListener('close', () => emitter.emit('disconnect'));
+
+    const api = {
+      on: (ev, fn) => { emitter.on(ev, fn); return api; },
+      off: (ev, fn) => { emitter.off(ev, fn); return api; },
+      send: obj => ws.send(JSON.stringify(obj)),
+      sendRaw: data => ws.send(data),
+      close: () => ws.close(),
+      socket: ws
+    };
+    return api;
+  }
+
+  if(typeof module !== 'undefined' && module.exports){
+    module.exports = { connect };
+  }
+  if(global){
+    global.connect = connect;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -1,0 +1,65 @@
+// tests/network.test.js
+
+describe('network.connect', () => {
+  let events;
+  let mockSocket;
+  let connect;
+  let conn;
+
+  beforeEach(() => {
+    jest.resetModules();
+    events = {};
+    mockSocket = {
+      send: jest.fn(),
+      close: jest.fn(),
+      addEventListener: jest.fn((ev, cb) => { events[ev] = cb; })
+    };
+    global.WebSocket = jest.fn(() => mockSocket);
+    connect = require('../js/network.js').connect;
+    conn = connect('ws://test');
+  });
+
+  afterEach(() => {
+    delete global.WebSocket;
+  });
+
+  test('emits connected on open', () => {
+    const handler = jest.fn();
+    conn.on('connected', handler);
+    events.open();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  test('emits parsed message', () => {
+    const handler = jest.fn();
+    conn.on('message', handler);
+    events.message({ data: '{"x":1}' });
+    expect(handler).toHaveBeenCalledWith({ x: 1 });
+  });
+
+  test('emits error', () => {
+    const handler = jest.fn();
+    conn.on('error', handler);
+    const err = new Error('fail');
+    events.error(err);
+    expect(handler).toHaveBeenCalledWith(err);
+  });
+
+  test('emits disconnect on close', () => {
+    const handler = jest.fn();
+    conn.on('disconnect', handler);
+    events.close();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  test('send sends JSON', () => {
+    const obj = { a: 1 };
+    conn.send(obj);
+    expect(mockSocket.send).toHaveBeenCalledWith(JSON.stringify(obj));
+  });
+
+  test('close closes socket', () => {
+    conn.close();
+    expect(mockSocket.close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `connect` helper to create WebSocket connections with event emitter
- allow JSON message sending via `send`/`sendRaw`
- test connection and messaging behaviour with mocked WebSocket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fecbeead88332b550e372846909e2