### PR TITLE
Add basic online lobby

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -247,6 +247,25 @@ h1 {
   z-index: 30;
   text-shadow: 0 0 6px #000;
 }
+#lobbyPanel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: radial-gradient(#222, #000);
+  color: #eee;
+  font: 1.1em 'Lora', serif;
+  z-index: 30;
+  text-shadow: 0 0 6px #000;
+}
+#lobbyPanel button{
+  margin: 6px;
+}
 #aiPanel button {
   margin-top: 10px;
   padding: 10px 20px;

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -94,4 +94,8 @@
   ,"statsUnits": "Units:"
   ,"logEnemy": "Enemy: {text}"
   ,"logTurn": "--- Turn {turn} ---"
+  ,"startOnline": "Online"
+  ,"createRoom": "Create room"
+  ,"joinRoom": "Join room"
+  ,"onlineTitle": "Online lobby"
 }

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -94,4 +94,8 @@
   ,"statsUnits": "Юнитов:"
   ,"logEnemy": "Враг: {text}"
   ,"logTurn": "--- Ход {turn} ---"
+  ,"startOnline": "Онлайн"
+  ,"createRoom": "Создать комнату"
+  ,"joinRoom": "Присоединиться"
+  ,"onlineTitle": "Лобби"
 }

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -94,4 +94,8 @@
   ,"statsUnits": "Юнітів:"
   ,"logEnemy": "Ворог: {text}"
   ,"logTurn": "--- Хід {turn} ---"
+  ,"startOnline": "Онлайн"
+  ,"createRoom": "Створити кімнату"
+  ,"joinRoom": "Приєднатися"
+  ,"onlineTitle": "Лобі"
 }

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
         </div>
         <button id="twoBtn" class="game-btn" data-i18n="startTwo">Start game</button>
         <button id="aiBtn" class="game-btn" data-i18n="startAi">Single player</button>
+        <button id="onlineBtn" class="game-btn" data-i18n="startOnline">Online</button>
         <button id="betaBtn" class="game-btn" data-i18n="startBeta">Extended mode (beta)</button>
       </div>
     </div>
@@ -84,6 +85,16 @@
       <option value="5" data-i18n="aiL5">Extreme</option>
     </select>
     <button id="aiStartBtn" class="game-btn" data-i18n="aiStart">Start</button>
+  </div>
+
+  <div id="lobbyPanel" style="display:none; flex-direction:column; align-items:center;">
+    <h1 data-i18n="onlineTitle">Online lobby</h1>
+    <input id="roomIdInput" placeholder="Room" />
+    <div>
+      <button id="createRoomBtn" class="game-btn" data-i18n="createRoom">Create room</button>
+      <button id="joinRoomBtn" class="game-btn" data-i18n="joinRoom">Join room</button>
+      <button id="lobbyBackBtn" class="game-btn" data-i18n="exitReplay">Menu</button>
+    </div>
   </div>
 
   <div id="overlay">
@@ -191,6 +202,7 @@
 
   <script src="js/ai.js"></script>
   <script src="js/dropdown.js"></script>
+  <script src="js/network.js"></script>
   <script src="js/core.js"></script>
 </body>
 </html>

--- a/js/core.js
+++ b/js/core.js
@@ -128,6 +128,12 @@ window.addEventListener('DOMContentLoaded', ()=>{
         fullscreenBtn = document.getElementById('fullscreenBtn'),
         newGameBtn   = document.getElementById('newGameBtn'),
         newGameOptions = document.getElementById('newGameOptions'),
+        onlineBtn   = document.getElementById('onlineBtn'),
+        lobbyPanel  = document.getElementById('lobbyPanel'),
+        roomIdInput = document.getElementById('roomIdInput'),
+        createRoomBtn = document.getElementById('createRoomBtn'),
+        joinRoomBtn = document.getElementById('joinRoomBtn'),
+        lobbyBackBtn = document.getElementById('lobbyBackBtn'),
         replaySideBtn = document.getElementById('replaySideBtn'),
         replayToggleBtn = document.getElementById('replayToggleBtn'),
         replayPauseBtn = document.getElementById('replayPauseBtn');
@@ -140,6 +146,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
   let mapSize = 'medium';
   const MIN_INFO_HEIGHT = 140;
   let aiMode = false, aiLevel = 2;
+  let lobbyConn = null;
   const TERRAIN = { PLAIN:0, WATER:1, FOREST:2, HILL:3, MOUNTAIN:4 };
   const TERR_COL  = ['#a6d88c','#6db6f8','#2e8b3d','#d4b55c','#8d8d8d'];
   // Plain 1, Water 2, Forest 2 (extra cost), Hill 2, Mountain impassable
@@ -1980,6 +1987,51 @@ window.addEventListener('DOMContentLoaded', ()=>{
     startPanel.style.display='none';
     generateWorld();
     recordTurn(); updateAll();
+  });
+
+  onlineBtn.addEventListener('click', ()=>{
+    if(newGameOptions) newGameOptions.style.display='none';
+    startPanel.style.display='none';
+    lobbyPanel.style.display='flex';
+  });
+
+  lobbyBackBtn.addEventListener('click', ()=>{
+    if(lobbyConn){ lobbyConn.close(); lobbyConn=null; }
+    lobbyPanel.style.display='none';
+    startPanel.style.display='flex';
+    if(newGameOptions) newGameOptions.style.display='flex';
+  });
+
+  function connectLobby(){
+    if(lobbyConn){ lobbyConn.close(); }
+    lobbyConn = connect((location.protocol==='https:'?'wss':'ws')+'://'+location.host);
+    lobbyConn.on('message', data=>{
+      if(data && data.action==='start'){
+        lobbyPanel.style.display='none';
+        waitOverlay.style.display='none';
+        twoBtn.click();
+      }
+    });
+    lobbyConn.on('disconnect', ()=>{
+      waitOverlay.style.display='none';
+      lobbyPanel.style.display='flex';
+    });
+  }
+
+  createRoomBtn.addEventListener('click', ()=>{
+    connectLobby();
+    const room = roomIdInput.value.trim();
+    lobbyConn.on('connected', ()=> lobbyConn.send({action:'create', room}));
+    lobbyPanel.style.display='none';
+    waitOverlay.style.display='flex';
+  });
+
+  joinRoomBtn.addEventListener('click', ()=>{
+    connectLobby();
+    const room = roomIdInput.value.trim();
+    lobbyConn.on('connected', ()=> lobbyConn.send({action:'join', room}));
+    lobbyPanel.style.display='none';
+    waitOverlay.style.display='flex';
   });
 
   // === Инициализация ===


### PR DESCRIPTION
## Summary
- add an Online button and lobby panel to the start screen
- load network.js and style the lobby overlay
- localize new online strings in English, Russian and Ukrainian
- implement lobby handling in `core.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fed97a48c83329c337aac875f3c6e