### PR TITLE
Refactor core into modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,8 @@
   <script src="js/ai.js"></script>
   <script src="js/dropdown.js"></script>
   <script src="js/network.js"></script>
-  <script src="js/core.js"></script>
+  <script src="js/gameState.js"></script>
+  <script src="js/replay.js"></script>
+  <script src="js/ui.js"></script>
 </body>
 </html>

--- a/js/gameState.js
+++ b/js/gameState.js
@@ -1,0 +1,61 @@
+(function(global){
+  const BASE_ROWS = 20, BASE_COLS = 30;
+  let ROWS = BASE_ROWS, COLS = BASE_COLS;
+  let mapSize = 'medium';
+  const TERRAIN = { PLAIN:0, WATER:1, FOREST:2, HILL:3, MOUNTAIN:4 };
+  const TERR_COL  = ['#a6d88c','#6db6f8','#2e8b3d','#d4b55c','#8d8d8d'];
+  const TERR_COST = [1,2,2,2,999];
+  const TERR_DEF  = [0,-1,1,2,0];
+  let TERR_LABELS = [];
+  const TILE_IMAGES = {
+    grass:['tiles/grass1'],
+    water:['tiles/water'],
+    pond:['tiles/pound','tiles/pound2','tiles/pound3'],
+    hill:['tiles/hill'],
+    mountain:['tiles/mountains3'],
+    forest:['tiles/trees1']
+  };
+  const UNIT_IMG_MAP = {
+    swordsman:'militia',
+    archer:'archer',
+    heavy:'heavy',
+    cavalry:'horseman',
+    mage:'healer',
+    bog:'militia'
+  };
+  const UNIT_TYPES = {
+    swordsman:{move:2,atk:2,def:1,range:1,hpMax:5,cost:3,color:'#e74c3c'},
+    archer:   {move:2,atk:3,def:0,range:2,hpMax:4,cost:4,color:'#2ecc71'},
+    heavy:    {move:1,atk:3,def:2,range:1,hpMax:6,cost:5,color:'#2c3e50'},
+    cavalry:  {move:3,atk:3,def:1,range:1,hpMax:5,cost:7,color:'#3498db'},
+    mage:     {move:2,atk:0,def:0,range:1,hpMax:4,cost:7,color:'#9b59b6'},
+    bog:      {move:1000,atk:2,def:1,range:1,hpMax:1000,cost:0,color:'#f1c40f'}
+  };
+  const BUILD_TYPES = {
+    base:      {spawn:['swordsman','archer'],gen:0,def:1,hpMax:4},
+    barracks:  {spawn:['heavy'],gen:0,def:0,hpMax:3},
+    stable:    {spawn:['cavalry'],gen:0,def:0,hpMax:3},
+    mageTower: {spawn:['mage'],gen:0,def:0,hpMax:3},
+    mill:      {spawn:[],gen:1,genUp:2,def:0,hpMax:2},
+    fort:      {spawn:[],gen:0,def:2,hpMax:4}
+  };
+  const BASE_SPAWN_DEFAULT = [...BUILD_TYPES.base.spawn];
+  const map = [];
+  const buildings = [];
+  const units = [];
+  const state = {
+    currentPlayer:1,
+    turn:0,
+    gold:{1:5,2:5},
+    fog:{}, seen:{},
+    grace:{1:null,2:null},
+    log:{1:[],2:[]}
+  };
+  let nextUnitId = 1;
+  Object.assign(global,{
+    BASE_ROWS,BASE_COLS,ROWS,COLS,mapSize,
+    TERRAIN,TERR_COL,TERR_COST,TERR_DEF,TERR_LABELS,
+    TILE_IMAGES,UNIT_IMG_MAP,UNIT_TYPES,BUILD_TYPES,
+    BASE_SPAWN_DEFAULT,map,buildings,units,state,nextUnitId
+  });
+})(typeof window!=='undefined'?window:this);

--- a/js/replay.js
+++ b/js/replay.js
@@ -1,0 +1,174 @@
+  function stopReplay(){
+    if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
+    aiReplay=[];
+    waitOverlay.style.display='none';
+    waitText.textContent=t('wait');
+    skipReplayBtn.style.display='none';
+    updateAll();
+  }
+
+  function replayAI(){
+    let i=0;
+    const run=()=>{
+      if(i>=aiReplay.length){ stopReplay(); return; }
+      const ev=aiReplay[i++];
+      if(ev.type==='move'){
+        animateMove(ev.unit,ev.from.r,ev.from.c,ev.to.r,ev.to.c);
+        replayTimer=setTimeout(run,300);
+      }else if(ev.type==='attack'){
+        animateShake(ev.target);
+        replayTimer=setTimeout(run,150);
+      }else{
+        replayTimer=setTimeout(run,250);
+      }
+      redraw();
+    };
+    run();
+  }
+
+  function applySnapshot(snap){
+    if(!snap) return;
+    units.length=0; snap.units.forEach(u=>units.push({...u}));
+    buildings.length=0; snap.buildings.forEach(b=>buildings.push({...b}));
+    state.currentPlayer = replaySide || snap.state.currentPlayer;
+    state.turn=snap.state.turn;
+    state.gold={...snap.state.gold};
+    updateAll();
+  }
+
+  function handleReplayAction(act){
+    if(!act) return;
+    if(act.type==='move'){
+      const u=units.find(x=>x.id===act.unit.id);
+      if(u) animateMove(u,act.from.r,act.from.c,act.to.r,act.to.c,200/replaySpeed);
+    }else if(act.type==='attack'){
+      let tgt=units.find(x=>x.id=== (act.target.id || act.target));
+      if(!tgt) tgt=buildings.find(b=>b.r===act.target.r && b.c===act.target.c);
+      if(tgt) animateShake(tgt,100/replaySpeed);
+    }
+  }
+
+  function handleNetEvent(ev){
+    if(!ev) return;
+    replayEvents.push(ev);
+    applySnapshot(ev.snapshot);
+    handleReplayAction(ev.action);
+  }
+
+  function handleNetMessage(data){
+    if(data && data.event) handleNetEvent(data.event);
+  }
+
+  function attachConnection(conn){
+    gameConn = conn;
+    onlineGame = !!conn;
+    window.gameConn = gameConn;
+    window.onlineGame = onlineGame;
+    if(conn) conn.on('message', handleNetMessage);
+  }
+
+  function startMatchReplay(){
+    if(!replayEvents.length) return;
+    replayIndex = 0;
+    replaySpeed = 1;
+    replayPaused = false;
+    replayControls.classList.remove('collapsed');
+    if(replayPauseBtn){
+      updateReplayPauseBtn();
+    }
+    if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));
+    window.replayPaused = replayPaused;
+    revealAll = true;
+    replaySide = 1;
+    currentReplaySnapshot = replayEvents[0].snapshot;
+    applySnapshot(currentReplaySnapshot);
+    if(replaySeek){
+      replaySeek.max = replayEvents.length - 1;
+      replaySeek.value = 0;
+    }
+    replayOverlay.style.display='flex';
+    if(speedBtns.length){
+      speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+      const def=document.querySelector('.speedBtn[data-speed="1"]');
+      if(def) def.classList.add('speed-selected');
+    }
+    runReplayStep = function(){
+      if(replayPaused || replayIndex >= replayEvents.length - 1){
+        if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();
+        return;
+      }
+      replayIndex++;
+      const ev = replayEvents[replayIndex];
+      handleReplayAction(ev.action);
+      const base = ev.action ? (ev.action.type==='move'?300:ev.action.type==='attack'?150:250) : 400;
+      replayTimer = setTimeout(()=>{
+        currentReplaySnapshot = ev.snapshot;
+        applySnapshot(ev.snapshot);
+        if(replaySeek) replaySeek.value = replayIndex;
+        runReplayStep();
+      }, base / replaySpeed);
+    };
+    runReplayStep();
+  }
+
+  function recordReplayVideo(){
+    if(videoRecorder && videoRecorder.state !== 'inactive'){
+      videoRecorder.stop();
+      return;
+    }
+    const stream = canvas.captureStream();
+    recordedChunks = [];
+    try{
+      videoRecorder = new MediaRecorder(stream);
+    }catch(e){
+      return;
+    }
+    videoRecorder.ondataavailable = e => {
+      if(e.data && e.data.size) recordedChunks.push(e.data);
+    };
+  videoRecorder.onstop = () => {
+      const blob = new Blob(recordedChunks, {type:'video/webm'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'replay.webm';
+      a.click();
+    };
+  videoRecorder.start();
+    replayPaused = false;
+    replaySpeed = 1;
+    speedBtns.forEach(b=>b.classList.remove('speed-selected'));
+    const def=document.querySelector('.speedBtn[data-speed="1"]');
+    if(def) def.classList.add('speed-selected');
+    updateReplayPauseBtn();
+    seekReplay(0);
+  }
+
+  function seekReplay(idx){
+    if(!replayEvents.length) return;
+    if(idx < 0) idx = 0;
+    if(idx > replayEvents.length - 1) idx = replayEvents.length - 1;
+    replayIndex = idx;
+    if(replaySeek) replaySeek.value = replayIndex;
+    currentReplaySnapshot = replayEvents[replayIndex].snapshot;
+    applySnapshot(currentReplaySnapshot);
+    if(!replayPaused && typeof runReplayStep === 'function'){
+      if(replayTimer){ clearTimeout(replayTimer); replayTimer = null; }
+      runReplayStep();
+    }
+  }
+  function stopMatchReplay(){
+    if(replayTimer){ clearTimeout(replayTimer); replayTimer=null; }
+    if(videoRecorder && videoRecorder.state !== 'inactive') videoRecorder.stop();
+    replayOverlay.style.display='none';
+    replayControls.classList.remove('collapsed');
+    if(replayPauseBtn){
+      updateReplayPauseBtn();
+    }
+    if(replayToggleBtn) replayToggleBtn.setAttribute('title', t('replayCollapse'));
+    runReplayStep = null;
+    replayPaused = false;
+    window.replayPaused = replayPaused;
+    replaySide = null;
+    revealAll = false;
+  }
+

--- a/js/ui.js
+++ b/js/ui.js
@@ -141,39 +141,13 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   // === Константы ===
   // default orientation switched to horizontal
-  const BASE_ROWS = 20, BASE_COLS = 30;
-  let ROWS = BASE_ROWS, COLS = BASE_COLS;
-  let mapSize = 'medium';
+  // constants moved to gameState.js
   const MIN_INFO_HEIGHT = 140;
   let aiMode = false, aiLevel = 2;
   let lobbyConn = null;
   let gameConn = null;
   let onlineGame = false;
-  const TERRAIN = { PLAIN:0, WATER:1, FOREST:2, HILL:3, MOUNTAIN:4 };
-  const TERR_COL  = ['#a6d88c','#6db6f8','#2e8b3d','#d4b55c','#8d8d8d'];
-  // Plain 1, Water 2, Forest 2 (extra cost), Hill 2, Mountain impassable
-  const TERR_COST = [1,2,2,2,999];
-  const TERR_DEF  = [0,-1,1,2,0];
-  let TERR_LABELS = [];
-
-  // tiles for drawing terrain
-  const TILE_IMAGES = {
-    grass:['tiles/grass1'],
-    water:['tiles/water'],
-    pond:['tiles/pound','tiles/pound2','tiles/pound3'],
-    hill:['tiles/hill'],
-    mountain:['tiles/mountains3'],
-    forest:['tiles/trees1']
-  };
-
-  const UNIT_IMG_MAP = {
-    swordsman:'militia',
-    archer:'archer',
-    heavy:'heavy',
-    cavalry:'horseman',
-    mage:'healer',
-    bog:'militia'
-  };
+  // terrain and unit data moved to gameState.js
 
   const SETTINGS_KEY = 'focSettings';
   const SAVE_PREFIX = 'focSave_';
@@ -390,18 +364,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   Object.assign(window, { spawnZones });
 
-  const state = {
-    currentPlayer:1,
-    turn:0,
-    gold:{1:5,2:5},
-    fog:{}, seen:{},
-    grace:{1:null,2:null},
-    log:{1:[],2:[]}
-  };
-
-  const map = [];
-  const buildings = [], units = [];
-  let nextUnitId = 1;
+  // state and map data moved to gameState.js
 
   // expose for tests
   Object.assign(window, {


### PR DESCRIPTION
## Summary
- split former `core.js` into `ui.js`, `gameState.js`, and `replay.js`
- adjust script loading order in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860239bc89083329273b126a97882c8