### PR TITLE
Add collapsible info panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -443,6 +443,12 @@ h1 {
   transform-origin: center; /* Ensure smooth scaling */
 }
 
+#panelToggleBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 #settingsBtn:hover:not(:disabled) {
   animation: pulse 0.4s ease;
 }
@@ -517,6 +523,18 @@ h1 {
 #legendBtn {
   margin-left: 8px;
   padding: 6px 10px;
+}
+
+#infoPanel.collapsed {
+  height: auto;
+}
+
+#infoPanel.collapsed #statsLog {
+  display: none;
+}
+
+#infoPanel.collapsed #controls {
+  border-bottom: none;
 }
 
 #legendOverlay,

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -38,6 +38,8 @@
   "settingsClose": "Close",
   "legendBtnTitle": "Legend",
   "settingsBtn": "Settings",
+  "infoCollapse": "Hide panel",
+  "infoExpand": "Show panel",
   "revealShow": "Show map",
   "revealHide": "Hide map",
   "tooltip": "Hints",

--- a/data/lang/ru.json
+++ b/data/lang/ru.json
@@ -38,6 +38,8 @@
   "settingsClose": "Закрыть",
   "legendBtnTitle": "Легенда",
   "settingsBtn": "Настройки",
+  "infoCollapse": "Свернуть панель",
+  "infoExpand": "Развернуть панель",
   "revealShow": "Показать карту",
   "revealHide": "Скрыть карту",
   "tooltip": "Подсказки",

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -38,6 +38,8 @@
   "settingsClose": "Закрити",
   "legendBtnTitle": "Легенда",
   "settingsBtn": "Налаштування",
+  "infoCollapse": "Згорнути панель",
+  "infoExpand": "Розгорнути панель",
   "revealShow": "Показати карту",
   "revealHide": "Сховати карту",
   "tooltip": "Підказки",

--- a/index.html
+++ b/index.html
@@ -196,6 +196,7 @@
     <div id="controls">
       <button id="legendBtn" class="game-btn" title="Legend" data-i18n-title="legendBtnTitle">ℹ️</button>
       <button id="settingsBtn" class="game-btn" title="Settings" data-i18n-title="settingsBtn">⚙</button>
+      <button id="panelToggleBtn" class="game-btn" title="Hide panel" data-i18n-title="infoCollapse">▼</button>
       <button id="revealBtn" class="game-btn" data-i18n="revealShow">Show map</button>
       <button id="endTurnBtn" class="game-btn" data-i18n="endTurn">End turn</button>
     </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -138,6 +138,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
         saveReplayBtn = document.getElementById('saveReplayBtn'),
         exitReplayBtn = document.getElementById('exitReplayBtn'),
         endTurnBtn  = document.getElementById('endTurnBtn'),
+        panelToggleBtn = document.getElementById('panelToggleBtn'),
+        infoPanel  = document.getElementById('infoPanel'),
         leftStats   = document.getElementById('leftStats'),
         rightLog    = document.getElementById('rightLog'),
         mapSizeSel  = document.getElementById('mapSizeSelect'),
@@ -307,6 +309,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
       const k=el.getAttribute('data-i18n-title');
       if(strings[k]) el.setAttribute('title', strings[k]);
     });
+    if(panelToggleBtn){
+      panelToggleBtn.textContent = infoPanel.classList.contains('collapsed') ? '▲' : '▼';
+    }
   }
 
   loadSettings();
@@ -512,7 +517,6 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
   // === Resize ===
   window.addEventListener('resize',()=>{
-    const infoPanel = document.getElementById('infoPanel');
     const size = Math.floor(Math.min(
       window.innerWidth / COLS,
       (window.innerHeight - MIN_INFO_HEIGHT) / ROWS
@@ -521,7 +525,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
     canvas.width  = cellW * COLS;
     canvas.height = cellH * ROWS;
     const panelH = Math.max(MIN_INFO_HEIGHT, window.innerHeight - canvas.height);
-    infoPanel.style.height = panelH + 'px';
+    if(!infoPanel.classList.contains('collapsed')){
+      infoPanel.style.height = panelH + 'px';
+    }
     infoPanel.style.bottom = '0';
     updateAll();
   });
@@ -1389,6 +1395,11 @@ window.addEventListener('DOMContentLoaded', ()=>{
       e.preventDefault();
       legendOverlay.style.display='flex';
     }
+  });
+  panelToggleBtn.addEventListener('click',()=>{
+    const collapsed = infoPanel.classList.toggle('collapsed');
+    panelToggleBtn.textContent = collapsed ? '▲' : '▼';
+    panelToggleBtn.setAttribute('title', t(collapsed ? 'infoExpand' : 'infoCollapse'));
   });
   legendOverlay.addEventListener('keydown',e=>{
     if(e.key==='Escape'){


### PR DESCRIPTION
## Summary
- add a toggle button to collapse/expand the info panel
- style collapsed panel and toggle button
- implement collapse logic in JS
- update translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686165d93d008332b2b65376968b064e