### PR TITLE
Adjust building capture logic

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -159,7 +159,7 @@
               u.r=enemy.r; u.c=enemy.c;
               let bb=buildings.find(b=>b.r===u.r&&b.c===u.c&&b.owner!==p);
               if(bb){
-                global.damageBuilding && global.damageBuilding(bb,p);
+                global.damageBuilding && global.damageBuilding(bb);
               }
               bb=buildings.find(b=>b.r===u.r&&b.c===u.c);
               if(bb) global.attemptCapture && global.attemptCapture(u, bb);
@@ -274,7 +274,7 @@
           u.mp-=moveCost;
           let bb=buildings.find(b=>b.r===target.r&&b.c===target.c&&b.owner!==p);
           if(bb){
-            global.damageBuilding && global.damageBuilding(bb,p);
+            global.damageBuilding && global.damageBuilding(bb);
           }
           global.addReplay && global.addReplay({type:'move',unit:u,from:{r:u.r,c:u.c},to:{r:target.r,c:target.c}});
           global.recordEvent && global.recordEvent(`${global.UNIT_LABELS[u.type]} переместился`);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1039,16 +1039,15 @@ window.addEventListener('DOMContentLoaded', ()=>{
     if(att.type==='cavalry' && BUILD_TYPES[bld.type].def>0) atk--;
     let defV=BUILD_TYPES[bld.type].def+TERR_DEF[map[bld.r][bld.c]];
     let dmg=Math.max(1,atk-defV);
-    damageBuilding(bld, att.owner, dmg);
+    damageBuilding(bld, dmg);
     return {dmg};
   }
 
-  function damageBuilding(b, newOwner, dmg=1){
+  function damageBuilding(b, dmg=1){
     if(!b) return;
     b.hp -= dmg;
     if(b.hp <= 0){
       b.hp = 0;
-      if(newOwner!==undefined) b.owner = newOwner;
     }
   }
 
@@ -1219,7 +1218,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
             animateMove(sel,sel.r,sel.c,tgt.r,tgt.c);
             sel.r=tgt.r; sel.c=tgt.c;
             let bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c&&b.owner!==p);
-            if(bb) damageBuilding(bb,p);
+            if(bb) damageBuilding(bb);
             bb=buildings.find(b=>b.r===sel.r&&b.c===sel.c);
             if(bb) attemptCapture(sel, bb);
           }
@@ -1273,7 +1272,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
           sel.mp=zoneMap.rem[y][x];
           let moved = (y!==sel.r || x!==sel.c);
           let bb=buildings.find(b=>b.r===y&&b.c===x&&b.owner!==p);
-          if(bb) damageBuilding(bb,p);
+          if(bb) damageBuilding(bb);
           if(moved && !aiMode) addReplay({type:'move',unit:sel,from,to:{r:y,c:x}});
           animateMove(sel,sel.r,sel.c,y,x);
           sel.r=y; sel.c=x;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -256,12 +256,16 @@ describe('Fog of Conquest core', () => {
   });
 
   test('destroying a building captures it for the attacker', () => {
-    const { buildings, damageBuilding, BUILD_TYPES } = window;
+    const { buildings, damageBuilding, attemptCapture, BUILD_TYPES } = window;
     document.getElementById('twoBtn').click();
     const base = buildings.find(b => b.owner === 1 && b.type === 'base');
     base.hp = 1;
-    damageBuilding(base, 2, 1);
+    damageBuilding(base, 1);
     expect(base.hp).toBe(0);
+    // owner unchanged until capture
+    expect(base.owner).toBe(1);
+    // simulate unit on tile capturing
+    attemptCapture({r:base.r,c:base.c,owner:2}, base);
     expect(base.owner).toBe(2);
   });
 
@@ -291,9 +295,10 @@ describe('Fog of Conquest core', () => {
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(1);
     for(let i=1;i<BUILD_TYPES.base.hpMax;i++){
-      window.damageBuilding(buildings[0],2);
+      window.damageBuilding(buildings[0]);
     }
-    expect(buildings[0].owner).toBe(2);
+    // owner should remain until capture
+    expect(buildings[0].owner).toBe(1);
     expect(buildings[0].hp).toBe(0);
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);
@@ -318,13 +323,14 @@ describe('Fog of Conquest core', () => {
     window.attemptCapture(archer, base);
     expect(base.owner).toBe(1);
     doAttackBuilding(archer, base);
-    expect(base.owner).toBe(2);
+    // owner unchanged until capture
+    expect(base.owner).toBe(1);
     expect(base.hp).toBe(0);
     expect(archer.r).toBe(0);
     expect(archer.c).toBe(0);
     window.attemptCapture(archer, base);
-    expect(base.owner).toBe(2);
-    // move archer onto the building and capture
+    expect(base.owner).toBe(1);
+    // move archer onto the building and capture/reset
     archer.r = base.r;
     archer.c = base.c;
     window.attemptCapture(archer, base);
@@ -398,7 +404,7 @@ describe('Fog of Conquest core', () => {
     click(0,2);
     const base = buildings[0];
     const archer = units[0];
-    expect(base.owner).toBe(2);
+    expect(base.owner).toBe(1);
     expect(base.hp).toBe(0);
     expect(archer.r).toBe(0);
     expect(archer.c).toBe(0);
@@ -577,8 +583,8 @@ describe('Fog of Conquest core', () => {
     expect(buildings[0].hp).toBe(BUILD_TYPES.base.hpMax - 1);
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(1);
-    for(let i=1;i<BUILD_TYPES.base.hpMax;i++) window.damageBuilding(buildings[0],2);
-    expect(buildings[0].owner).toBe(2);
+    for(let i=1;i<BUILD_TYPES.base.hpMax;i++) window.damageBuilding(buildings[0]);
+    expect(buildings[0].owner).toBe(1);
     expect(buildings[0].hp).toBe(0);
     window.attemptCapture(units[0], buildings[0]);
     expect(buildings[0].owner).toBe(2);


### PR DESCRIPTION
## Summary
- decouple damage from capture by simplifying `damageBuilding`
- ensure units attempt capture when standing on a destroyed building
- update AI and UI to use new `damageBuilding`
- adapt unit tests for the new capture mechanic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68616da6e8f48332ac92be13ddc6c8ac