### PR TITLE
Improve map generation and AI logic

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -109,13 +109,21 @@
     const p=2,
           F=state.fog[p];
     const enemyUnits=units.filter(u=>u.owner===1 && !F[u.r][u.c]);
-    const enemyBuildings=buildings.filter(b=>b.owner===1 && !F[b.r][b.c]);
+    const captureBuildings=buildings.filter(b=>b.owner!==p && !F[b.r][b.c]);
+    const enemyBuildings=captureBuildings.filter(b=>b.owner===1);
     const enemyBases=enemyBuildings.filter(b=>BUILD_TYPES[b.type].gen===0);
     const baseDist=enemyBases.length?computeDistanceMap(enemyBases):null;
-    const buildDist=enemyBuildings.length?computeDistanceMap(enemyBuildings):null;
+    const captureDist=captureBuildings.length?computeDistanceMap(captureBuildings):null;
     const unitDist=enemyUnits.length?computeDistanceMap(enemyUnits):null;
     const allEnemies=[...enemyUnits,...enemyBuildings];
     const allDist=allEnemies.length?computeDistanceMap(allEnemies):null;
+    const unseenCells=[];
+    if(state.seen&&state.seen[p]){
+      for(let r=0;r<ROWS;r++)for(let c=0;c<COLS;c++){
+        if(!state.seen[p][r][c]) unseenCells.push({r,c});
+      }
+    }
+    const exploreDist=unseenCells.length?computeDistanceMap(unseenCells):null;
     const enemyCounts={};
     enemyUnits.forEach(u=>enemyCounts[u.type]=(enemyCounts[u.type]||0)+1);
     buildings.filter(b=>b.owner===p && BUILD_TYPES[b.type].spawn.length).forEach(b=>{
@@ -176,13 +184,17 @@
         }else if(aiLevel===2){
           if(allDist){
             target=cz.list.sort((a,b)=>allDist[a.r][a.c]-allDist[b.r][b.c])[0];
-          } else target=cz.list[0];
+          } else if(captureDist){
+            target=cz.list.sort((a,b)=>captureDist[a.r][a.c]-captureDist[b.r][b.c])[0];
+          } else if(exploreDist){
+            target=cz.list.sort((a,b)=>exploreDist[a.r][a.c]-exploreDist[b.r][b.c])[0];
+          } else target=cz.list[Math.random()*cz.list.length|0];
         }else{
           let best=null,bestScore=-Infinity;
           cz.list.forEach(pos=>{
             let score=0;
             const br=baseDist?baseDist[pos.r][pos.c]:null,
-                  bd=buildDist?buildDist[pos.r][pos.c]:null,
+                  bd=captureDist?captureDist[pos.r][pos.c]:null,
                   ud=unitDist?unitDist[pos.r][pos.c]:null;
             let bw,blw,uw;
             if(aiLevel>=6){
@@ -197,7 +209,7 @@
               bw=3; blw=1; uw=2;
             }
             if(baseDist) score-= (br||100)*bw;
-            if(buildDist) score-= (bd||100)*blw;
+            if(captureDist) score-= (bd||100)*blw;
             if(unitDist) score-= (ud||100)*uw;
 
             const terrainBonus=(TERR_DEF?TERR_DEF[map[pos.r][pos.c]]:0);
@@ -248,6 +260,9 @@
             });
             if(risk>=u.hp) risk+= (UNIT_VALUE[u.type]||UNIT_TYPES[u.type].cost||0);
             score-=risk;
+            if(exploreDist){
+              score-= (exploreDist[pos.r][pos.c]||100)*0.5;
+            }
 
             if(aiLevel>=4 && u.hp<=UNIT_TYPES[u.type].hpMax/2){
               let distAway=allDist?allDist[pos.r][pos.c]:0;

--- a/js/worldGen.js
+++ b/js/worldGen.js
@@ -21,6 +21,7 @@
     ensureConnectivity();
     balanceStarts();
     spiceRandom();
+    ensureTerrainPresence();
 
     global.units.push({id:global.nextUnitId++,r:1,c:2,owner:1,type:'swordsman',
       hp:global.UNIT_TYPES.swordsman.hpMax,
@@ -59,7 +60,14 @@
     }
     let min=Infinity,max=-Infinity;
     for(let r=0;r<rows;r++)for(let c=0;c<cols;c++){const v=map[r][c];if(v<min)min=v;if(v>max)max=v;}
-    for(let r=0;r<rows;r++)for(let c=0;c<cols;c++){map[r][c]=(map[r][c]-min)/(max-min);}
+    for(let r=0;r<rows;r++)for(let c=0;c<cols;c++){
+      let v=(map[r][c]-min)/(max-min);
+      const dx=r-rows/2, dy=c-cols/2;
+      const dist=Math.sqrt(dx*dx+dy*dy);
+      const maxDist=Math.sqrt((rows/2)**2+(cols/2)**2);
+      const falloff=1-dist/maxDist;
+      map[r][c]=v*0.7+falloff*0.3;
+    }
     for(let k=0;k<2;k++) boxBlur(map);
     return map;
   }
@@ -197,6 +205,18 @@
       if(v<RESOURCE_CHANCE/2) global.map[r][c]=global.TERRAIN.FOREST;
       else if(v<RESOURCE_CHANCE) global.map[r][c]=global.TERRAIN.HILL;
     }
+  }
+
+  function ensureTerrainPresence(){
+    const types=[global.TERRAIN.WATER,global.TERRAIN.FOREST,global.TERRAIN.HILL,global.TERRAIN.MOUNTAIN];
+    types.forEach(t=>{
+      if(!global.map.some(row=>row.includes(t))){
+        for(let i=0;i<1000;i++){
+          const r=Math.random()*global.ROWS|0, c=Math.random()*global.COLS|0;
+          if(global.map[r][c]===global.TERRAIN.PLAIN){ global.map[r][c]=t; break; }
+        }
+      }
+    });
   }
 
   function rand2(x,y){


### PR DESCRIPTION
## Summary
- refine world generation using radial noise and ensure at least one of each terrain
- expand AI awareness of neutral buildings and unseen areas
- allow AI to select targets for exploration when no enemies are visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e1d66768833285c58c57f528e31b